### PR TITLE
fix: TasksView 模板多余闭合标签导致构建失败

### DIFF
--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -214,7 +214,6 @@
                 <button class="time-range-pill" :class="{ active: createForm.mode === 'sustained' }" @click="createForm.mode = 'sustained'">持续</button>
               </div>
             </div>
-            </div>
             <div class="form-group">
               <label class="form-label">最大 Token</label>
               <input class="form-input" type="number" v-model.number="createForm.max_tokens" min="1" placeholder="512">


### PR DESCRIPTION
## Summary
- TasksView.vue 第 217 行有一个多余的 `</div>`，导致 Vue 模板编译失败，Docker 构建中断

## Test plan
- [x] `bun run build` 构建成功