### PR TITLE
fix: bench/start 补传 custom_endpoint 字段

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -759,6 +759,7 @@ async def update_profile(name: str, request: Request, user: dict = Depends(get_c
         model=model,
         provider=data.get("provider", ""),
         protocol=data.get("protocol", ""),
+        custom_endpoint=1 if data.get("custom_endpoint") else 0,
         set_active=data.get("set_active", False),
     )
     return {"status": "ok"}

--- a/frontend/src/components/SiteConfigTab.vue
+++ b/frontend/src/components/SiteConfigTab.vue
@@ -200,6 +200,7 @@ async function dryRunTest() {
         base_url: form.value.base_url,
         api_key: form.value.api_key,
         model: form.value.models[0] || '',
+        custom_endpoint: form.value.custom_endpoint,
         concurrency_levels: [1],
         requests_per_level: 1,
         mode: 'burst',

--- a/frontend/src/components/SiteTestTab.vue
+++ b/frontend/src/components/SiteTestTab.vue
@@ -401,6 +401,7 @@ function buildConfig(model) {
     api_key: props.profile.api_key_display || props.profile.api_key,
     model,
     provider: props.profile.provider || '',
+    custom_endpoint: props.profile.custom_endpoint || false,
     concurrency_levels: [conc],
     mode: form.value.mode,
     max_tokens: parseInt(form.value.max_tokens) || 512,

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -549,6 +549,7 @@ async function dryRunTest() {
         api_key: form.value.api_key,
         model: form.value.models[0] || '',
         provider: form.value.provider,
+        custom_endpoint: form.value.custom_endpoint || false,
         concurrency_levels: [1],
         requests_per_level: 1,
         mode: 'burst',

--- a/frontend/src/views/SitesView.vue
+++ b/frontend/src/views/SitesView.vue
@@ -426,6 +426,7 @@ async function confirmTest() {
         api_key: profile.api_key_display || '',
         model: profile.models[0],
         provider: profile.provider || '',
+        custom_endpoint: profile.custom_endpoint || false,
         concurrency_levels: [10],
         requests_per_level: 10,
         mode: 'burst',


### PR DESCRIPTION
## Summary
- 前端 4 处 bench/start 调用（SiteTestTab、SiteConfigTab、SitesView、ProfileView）均未传递 `custom_endpoint`，导致完整 URL 模式不生效
- 修复 `PUT /api/profiles/{name}` 端点漏传 `custom_endpoint`

## Root cause
前端发起 benchmark 时请求体中没有 `custom_endpoint` 字段，后端虽然从 active profile 加载，但 active profile 可能不是当前编辑的 profile