### PR TITLE
fix: 通知弹窗分区 + 刷新按钮整改

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,7 +9,6 @@
       </div>
     </div>
     <div class="header-right" v-if="store.user">
-      <button v-if="store.refreshFn" class="btn btn-ghost btn-sm header-refresh" @click="store.refreshFn()" title="刷新"><i class="ph ph-arrows-clockwise"></i></button>
       <ScheduleIndicator />
       <div class="user-menu" v-click-outside="() => userMenuOpen = false">
         <button class="user-avatar" @click="userMenuOpen = !userMenuOpen">
@@ -46,6 +45,7 @@
   <nav class="tab-bar" v-if="store.user && !store.user.must_change_password">
     <router-link v-for="tab in tabs" :key="tab.path" :to="tab.path" class="tab-btn" :class="{ active: tab.activeMatch ? tab.activeMatch($route.path) : $route.path === tab.path }" @click="userMenuOpen = false">{{ tab.name }}</router-link>
     <div class="time-range-pills global-time-range">
+      <button class="time-range-pill refresh-pill" :class="{ disabled: !store.refreshFn }" @click="store.refreshFn && store.refreshFn()" title="刷新"><i class="ph ph-arrows-clockwise"></i></button>
       <button v-for="opt in timeRangeStore.options" :key="opt.label" class="time-range-pill" :class="{ active: timeRangeStore.hours === opt.value }" @click="timeRangeStore.setHours(opt.value)">{{ opt.label }}</button>
     </div>
   </nav>

--- a/frontend/src/components/ScheduleIndicator.vue
+++ b/frontend/src/components/ScheduleIndicator.vue
@@ -27,7 +27,7 @@
     </div>
   </div>
 
-  <!-- 右下角完成通知 -->
+  <!-- 右上角完成通知 -->
   <Teleport to="body">
     <div class="done-toast-stack" v-if="doneNotifications.length > 0">
       <div
@@ -374,14 +374,14 @@ onUnmounted(() => {
 </style>
 
 <style>
-/* 右下角完成通知栈 */
+/* 右上角完成通知栈 */
 .done-toast-stack {
   position: fixed;
-  bottom: 20px;
+  top: 56px;
   right: 20px;
   z-index: 2000;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   gap: 8px;
   width: 300px;
 }
@@ -405,8 +405,8 @@ onUnmounted(() => {
 }
 
 @keyframes doneToastIn {
-  from { opacity: 0; transform: translateX(30px); }
-  to { opacity: 1; transform: translateX(0); }
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .done-toast-left {

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -974,6 +974,18 @@ tbody tr:last-child td { border-bottom: none; }
   color: var(--accent);
   font-weight: 600;
 }
+.time-range-pill.refresh-pill {
+  font-family: inherit;
+  padding: 5px 8px;
+  font-size: 13px;
+  line-height: 1;
+}
+.time-range-pill.refresh-pill .ph { display: block; }
+.time-range-pill.refresh-pill.disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
 
 .filter-dropdown {
   position: relative;

--- a/frontend/src/views/SiteDetailView.vue
+++ b/frontend/src/views/SiteDetailView.vue
@@ -80,6 +80,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getProfiles, getSitesSummary } from '../api';
 import { toast } from '../composables/useToast';
+import { useAppStore } from '../stores/app';
 import SiteConfigTab from '../components/SiteConfigTab.vue';
 import SiteTestTab from '../components/SiteTestTab.vue';
 import SiteSchedulesTab from '../components/SiteSchedulesTab.vue';
@@ -89,6 +90,7 @@ const route = useRoute();
 const router = useRouter();
 
 const props = defineProps({ id: { type: String, required: true } });
+const store = useAppStore();
 
 const siteName = computed(() => decodeURIComponent(props.id));
 const loading = ref(false);
@@ -163,10 +165,12 @@ watch(() => route.params.id, () => {
 }, { immediate: true });
 
 onMounted(() => {
+  store.refreshFn = loadSiteData;
   document.addEventListener('click', onClickOutside);
 });
 
 onUnmounted(() => {
+  store.refreshFn = null;
   document.removeEventListener('click', onClickOutside);
 });
 </script>


### PR DESCRIPTION
## Summary
- Done-Toast（任务完成通知）从右下角移到右上角，不再与 Toast 重叠
- 刷新按钮从 header 移到 tab-bar 的时间范围 pill 左侧，采用统一的 pill 风格
- SiteDetailView 注册 refreshFn，解决站点详情页刷新按钮消失的问题
- 无 refreshFn 时按钮显示为 disabled 状态而非隐藏

## Test plan
- [x] 前端构建成功
- [x] 114 个后端测试全部通过