### PR TITLE
feat: 消息中心 + 模型管理整改

### DIFF
--- a/app/builtin_models.py
+++ b/app/builtin_models.py
@@ -21,24 +21,14 @@ DEFAULT_VENDORS = [
 ]
 
 DEFAULT_MODELS = [
-    {"id": "claude-opus-4-20250514", "vendor": "anthropic", "enabled": True},
-    {"id": "claude-sonnet-4-20250514", "vendor": "anthropic", "enabled": True},
-    {"id": "claude-haiku-4-20250514", "vendor": "anthropic", "enabled": True},
-    {"id": "gpt-4o", "vendor": "openai", "enabled": True},
-    {"id": "gpt-4o-mini", "vendor": "openai", "enabled": True},
-    {"id": "o3", "vendor": "openai", "enabled": True},
-    {"id": "o4-mini", "vendor": "openai", "enabled": True},
-    {"id": "deepseek-chat", "vendor": "deepseek", "enabled": True},
-    {"id": "deepseek-reasoner", "vendor": "deepseek", "enabled": True},
-    {"id": "qwen-max", "vendor": "qwen", "enabled": True},
-    {"id": "qwen-plus", "vendor": "qwen", "enabled": True},
-    {"id": "gemini-2.5-pro", "vendor": "google", "enabled": True},
-    {"id": "gemini-2.5-flash", "vendor": "google", "enabled": True},
-    {"id": "mistral-large-latest", "vendor": "mistral", "enabled": True},
-    {"id": "glm-4-plus", "vendor": "zhipu", "enabled": True},
-    {"id": "moonshot-v1-auto", "vendor": "moonshot", "enabled": True},
-    {"id": "doubao-pro-32k", "vendor": "bytedance", "enabled": True},
-    {"id": "command-r-plus", "vendor": "cohere", "enabled": True},
+    {"id": "claude-opus-4-6", "vendor": "anthropic", "enabled": True},
+    {"id": "claude-sonnet-4-6", "vendor": "anthropic", "enabled": True},
+    {"id": "claude-haiku-4-5-20251001", "vendor": "anthropic", "enabled": True},
+    {"id": "gpt-5.4", "vendor": "openai", "enabled": True},
+    {"id": "gpt-5.3-codex", "vendor": "openai", "enabled": True},
+    {"id": "gpt-5.2", "vendor": "openai", "enabled": True},
+    {"id": "gemini-3-pro-preview", "vendor": "google", "enabled": True},
+    {"id": "gemini-3-flash-lite-preview", "vendor": "google", "enabled": True},
 ]
 
 _JSON_FILENAME = "builtin_models.json"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,6 +10,7 @@
     </div>
     <div class="header-right" v-if="store.user">
       <ScheduleIndicator />
+      <NotificationCenter />
       <div class="user-menu" v-click-outside="() => userMenuOpen = false">
         <button class="user-avatar" @click="userMenuOpen = !userMenuOpen">
           {{ (store.user?.email || '?')[0].toUpperCase() }}
@@ -79,6 +80,7 @@ import { useAppStore } from './stores/app';
 import { useTimeRangeStore } from './stores/timeRange';
 import { useRouter, useRoute } from 'vue-router';
 import ScheduleIndicator from './components/ScheduleIndicator.vue';
+import NotificationCenter from './components/NotificationCenter.vue';
 
 const store = useAppStore();
 const timeRangeStore = useTimeRangeStore();

--- a/frontend/src/components/NotificationCenter.vue
+++ b/frontend/src/components/NotificationCenter.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="notification-center" ref="containerRef">
+    <button class="notification-bell" @click.stop="togglePanel" :class="{ 'has-unread': unreadCount() > 0 }">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/></svg>
+      <span v-if="unreadCount() > 0" class="notification-badge">{{ unreadCount() > 9 ? '9+' : unreadCount() }}</span>
+    </button>
+    <div class="notification-panel" v-show="panelOpen" @click.stop>
+      <div class="notification-panel-header">
+        <span class="notification-panel-title">消息中心</span>
+        <button v-if="notifications.length" class="btn btn-ghost btn-sm" @click="clearAll" style="font-size:11px;padding:2px 8px">清空</button>
+      </div>
+      <div class="notification-panel-list">
+        <div v-if="!notifications.length" class="notification-empty">暂无消息</div>
+        <div
+          v-for="n in reversedNotifications"
+          :key="n.id"
+          class="notification-item"
+          :class="{ unread: !n.read }"
+          @click="onItemClick(n)"
+        >
+          <div class="notification-item-icon" :class="{ 'has-fail': n.hasFail }">
+            <svg v-if="!n.hasFail" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          </div>
+          <div class="notification-item-content">
+            <div class="notification-item-title">{{ n.title }}</div>
+            <div class="notification-item-models">{{ n.modelsText }}</div>
+            <div class="notification-item-meta">{{ n.subtitle }} · {{ timeAgo(n.time) }}</div>
+          </div>
+          <button class="notification-item-dismiss" @click.stop="dismiss(n.id)">&times;</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useNotifications } from '../composables/useNotifications.js';
+
+const router = useRouter();
+const { notifications, dismiss, markAllRead, clearAll, unreadCount } = useNotifications();
+
+const panelOpen = ref(false);
+const containerRef = ref(null);
+
+const reversedNotifications = computed(() => [...notifications.value].reverse());
+
+function togglePanel() {
+  panelOpen.value = !panelOpen.value;
+  if (panelOpen.value) {
+    markAllRead();
+  }
+}
+
+function onItemClick(n) {
+  if (n.profileName) {
+    router.push(`/sites/${encodeURIComponent(n.profileName)}?tab=trends`);
+  }
+  panelOpen.value = false;
+}
+
+function timeAgo(ts) {
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return '刚刚';
+  if (diff < 3600) return `${Math.floor(diff / 60)} 分钟前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} 小时前`;
+  return `${Math.floor(diff / 86400)} 天前`;
+}
+
+let clickOutsideHandler = null;
+onMounted(() => {
+  clickOutsideHandler = (e) => {
+    if (containerRef.value && !containerRef.value.contains(e.target)) {
+      panelOpen.value = false;
+    }
+  };
+  document.addEventListener('click', clickOutsideHandler);
+});
+onUnmounted(() => {
+  if (clickOutsideHandler) document.removeEventListener('click', clickOutsideHandler);
+});
+</script>
+
+<style scoped>
+.notification-center {
+  position: relative;
+}
+
+.notification-bell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  transition: var(--transition);
+}
+
+.notification-bell:hover {
+  color: var(--text-primary);
+  background: var(--bg);
+}
+
+.notification-bell.has-unread {
+  color: var(--text-secondary);
+}
+
+.notification-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--danger);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+}
+
+.notification-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 340px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.notification-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.notification-panel-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.notification-panel-list {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.notification-empty {
+  padding: 32px 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+.notification-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 0.1s;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}
+
+.notification-item:hover {
+  background: var(--bg);
+}
+
+.notification-item.unread {
+  background: var(--accent-light);
+}
+
+.notification-item.unread:hover {
+  background: color-mix(in srgb, var(--accent-light) 80%, var(--bg));
+}
+
+.notification-item-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+  background: var(--success-light, #e6f4ec);
+  color: var(--success, #2D8B55);
+}
+
+.notification-item-icon.has-fail {
+  background: var(--danger-light, #fef0f0);
+  color: var(--danger, #D63B3B);
+}
+
+.notification-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-item-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notification-item-models {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+
+.notification-item-meta {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 1px;
+}
+
+.notification-item-dismiss {
+  background: none;
+  border: none;
+  font-size: 14px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s;
+}
+
+.notification-item:hover .notification-item-dismiss {
+  opacity: 1;
+}
+
+.notification-item-dismiss:hover {
+  color: var(--text-primary);
+}
+</style>

--- a/frontend/src/components/ScheduleIndicator.vue
+++ b/frontend/src/components/ScheduleIndicator.vue
@@ -26,48 +26,22 @@
       </div>
     </div>
   </div>
-
-  <!-- 右上角完成通知 -->
-  <Teleport to="body">
-    <div class="done-toast-stack" v-if="doneNotifications.length > 0">
-      <div
-        v-for="n in doneNotifications"
-        :key="n.id"
-        class="done-toast"
-        @click="onNotifyClick(n)"
-      >
-        <div class="done-toast-left" :class="{ 'has-fail': n.hasFail }">
-          <svg v-if="!n.hasFail" class="done-toast-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-          <svg v-else class="done-toast-warn" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-        </div>
-        <div class="done-toast-content">
-          <div class="done-toast-title">{{ n.title }}</div>
-          <div class="done-toast-models">{{ n.modelsText }}</div>
-          <div class="done-toast-meta">{{ n.subtitle }}</div>
-        </div>
-        <button class="done-toast-dismiss" @click.stop="dismissNotify(n.id)">&times;</button>
-      </div>
-    </div>
-  </Teleport>
 </template>
 
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
-import { useRouter } from 'vue-router';
 import { getRunningTasks } from '../api/index.js';
+import { useNotifications } from '../composables/useNotifications.js';
 
-const router = useRouter();
+const { upsert: pushNotification } = useNotifications();
 
 const panelOpen = ref(false);
 const runningTasks = ref([]);
 const indicatorRef = ref(null);
 
-// 完成通知 — 按 profile_name 聚合（同站点只保留一条，持续更新）
-const doneNotifications = ref([]);
+// 完成通知 — 委托给 useNotifications composable
 let prevTaskIds = new Set();
-let prevTaskMeta = new Map(); // task_id -> { model, profile_name, elapsed }
-let notifyIdCounter = 0;
-const MAX_NOTIFICATIONS = 5;
+let prevTaskMeta = new Map();
 
 function togglePanel() {
   panelOpen.value = !panelOpen.value;
@@ -76,67 +50,6 @@ function togglePanel() {
 function progressPct(t) {
   if (!t.total || t.total === 0) return 0;
   return Math.min(100, Math.round(t.done / t.total * 100));
-}
-
-function upsertNotification(profileName, models, maxElapsed, isScheduled, success, failed) {
-  const existing = doneNotifications.value.find(n => n.profileName === profileName && n.isScheduled === isScheduled);
-  const totalRuns = (existing?.runCount || 0) + 1;
-  const allModels = existing ? [...new Set([...existing.models, ...models])] : [...new Set(models)];
-  const modelsText = allModels.length > 2
-    ? `${allModels.slice(0, 2).join(', ')} 等 ${allModels.length} 个模型`
-    : allModels.join(', ');
-  const prefix = isScheduled ? '定时任务' : '单次测试';
-
-  const total = success + failed;
-  let resultText;
-  if (total === 0) {
-    resultText = `用时 ${maxElapsed}s`;
-  } else if (failed === 0) {
-    resultText = `全部成功 · 用时 ${maxElapsed}s`;
-  } else {
-    resultText = `${success}/${total} 成功 · 用时 ${maxElapsed}s`;
-  }
-  const subtitle = totalRuns > 1
-    ? `已完成 ${totalRuns} 次 · ${resultText}`
-    : resultText;
-  const hasFail = failed > 0;
-
-  if (existing) {
-    existing.models = allModels;
-    existing.modelsText = modelsText;
-    existing.subtitle = subtitle;
-    existing.runCount = totalRuns;
-    existing.hasFail = hasFail;
-    existing.time = Date.now();
-  } else {
-    notifyIdCounter++;
-    doneNotifications.value.push({
-      id: notifyIdCounter,
-      title: `${prefix}：${profileName || '测试'} 完成`,
-      models: allModels,
-      modelsText,
-      subtitle,
-      profileName,
-      isScheduled,
-      hasFail,
-      runCount: totalRuns,
-      time: Date.now(),
-    });
-    while (doneNotifications.value.length > MAX_NOTIFICATIONS) {
-      doneNotifications.value.shift();
-    }
-  }
-}
-
-function dismissNotify(id) {
-  doneNotifications.value = doneNotifications.value.filter(n => n.id !== id);
-}
-
-function onNotifyClick(n) {
-  if (n.profileName) {
-    router.push(`/sites/${encodeURIComponent(n.profileName)}?tab=trends`);
-  }
-  dismissNotify(n.id);
 }
 
 function detectCompleted(currentTasks) {
@@ -172,7 +85,7 @@ function detectCompleted(currentTasks) {
 
   // 对每个站点 upsert 通知（同站点同类型多次完成会聚合到同一条）
   for (const [, g] of Object.entries(grouped)) {
-    upsertNotification(g.profile_name, g.models, g.elapsed, g.scheduled, g.success, g.failed);
+    pushNotification(g.profile_name, g.models, g.elapsed, g.scheduled, g.success, g.failed);
   }
 
   for (const id of completedIds) {
@@ -370,113 +283,5 @@ onUnmounted(() => {
   font-family: var(--font-mono);
   color: var(--text-tertiary);
   white-space: nowrap;
-}
-</style>
-
-<style>
-/* 右上角完成通知栈 */
-.done-toast-stack {
-  position: fixed;
-  top: 56px;
-  right: 20px;
-  z-index: 2000;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 300px;
-}
-
-.done-toast {
-  display: flex;
-  align-items: stretch;
-  background: var(--surface-raised, #fff);
-  border: 1px solid var(--border, #E8E6E1);
-  border-radius: var(--radius, 10px);
-  box-shadow: var(--shadow-md, 0 4px 16px rgba(0,0,0,0.06));
-  cursor: pointer;
-  overflow: hidden;
-  animation: doneToastIn 0.2s ease;
-  transition: box-shadow 0.15s, transform 0.15s;
-}
-
-.done-toast:hover {
-  box-shadow: var(--shadow-lg, 0 8px 32px rgba(0,0,0,0.08));
-  transform: translateY(-1px);
-}
-
-@keyframes doneToastIn {
-  from { opacity: 0; transform: translateY(-10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.done-toast-left {
-  width: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: var(--success-light, #e6f4ec);
-}
-
-.done-toast-check {
-  stroke: var(--success, #2D8B55);
-}
-
-.done-toast-left.has-fail {
-  background: var(--danger-light, #fef0f0);
-}
-
-.done-toast-warn {
-  stroke: var(--danger, #D63B3B);
-}
-
-.done-toast-content {
-  flex: 1;
-  min-width: 0;
-  padding: 10px 0 10px 10px;
-}
-
-.done-toast-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary, #1A1A18);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.3;
-}
-
-.done-toast-models {
-  font-size: 11px;
-  font-family: var(--font-mono, monospace);
-  color: var(--text-secondary, #6B6B65);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-top: 2px;
-}
-
-.done-toast-meta {
-  font-size: 11px;
-  color: var(--text-tertiary, #9C9C96);
-  margin-top: 2px;
-  white-space: nowrap;
-}
-
-.done-toast-dismiss {
-  background: none;
-  border: none;
-  font-size: 16px;
-  color: var(--text-tertiary, #9C9C96);
-  cursor: pointer;
-  padding: 8px 10px;
-  line-height: 1;
-  flex-shrink: 0;
-  align-self: flex-start;
-  transition: color 0.15s;
-}
-
-.done-toast-dismiss:hover {
-  color: var(--text-primary, #1A1A18);
 }
 </style>

--- a/frontend/src/composables/useNotifications.js
+++ b/frontend/src/composables/useNotifications.js
@@ -1,0 +1,84 @@
+import { ref } from 'vue';
+
+const notifications = ref([]);
+let idCounter = 0;
+const MAX = 20;
+
+export function useNotifications() {
+  function add(notification) {
+    idCounter++;
+    notifications.value.push({ ...notification, id: idCounter, time: Date.now(), read: false });
+    while (notifications.value.length > MAX) {
+      notifications.value.shift();
+    }
+  }
+
+  function upsert(profileName, models, maxElapsed, isScheduled, success, failed) {
+    const existing = notifications.value.find(n => n.profileName === profileName && n.isScheduled === isScheduled && !n.read);
+    const totalRuns = (existing?.runCount || 0) + 1;
+    const allModels = existing ? [...new Set([...existing.models, ...models])] : [...new Set(models)];
+    const modelsText = allModels.length > 2
+      ? `${allModels.slice(0, 2).join(', ')} 等 ${allModels.length} 个模型`
+      : allModels.join(', ');
+    const prefix = isScheduled ? '定时任务' : '单次测试';
+
+    const total = success + failed;
+    let resultText;
+    if (total === 0) {
+      resultText = `用时 ${maxElapsed}s`;
+    } else if (failed === 0) {
+      resultText = `全部成功 · 用时 ${maxElapsed}s`;
+    } else {
+      resultText = `${success}/${total} 成功 · 用时 ${maxElapsed}s`;
+    }
+    const subtitle = totalRuns > 1
+      ? `已完成 ${totalRuns} 次 · ${resultText}`
+      : resultText;
+    const hasFail = failed > 0;
+
+    if (existing) {
+      existing.models = allModels;
+      existing.modelsText = modelsText;
+      existing.subtitle = subtitle;
+      existing.runCount = totalRuns;
+      existing.hasFail = hasFail;
+      existing.time = Date.now();
+    } else {
+      idCounter++;
+      notifications.value.push({
+        id: idCounter,
+        title: `${prefix}：${profileName || '测试'} 完成`,
+        models: allModels,
+        modelsText,
+        subtitle,
+        profileName,
+        isScheduled,
+        hasFail,
+        runCount: totalRuns,
+        read: false,
+        time: Date.now(),
+      });
+      while (notifications.value.length > MAX) {
+        notifications.value.shift();
+      }
+    }
+  }
+
+  function dismiss(id) {
+    notifications.value = notifications.value.filter(n => n.id !== id);
+  }
+
+  function markAllRead() {
+    for (const n of notifications.value) {
+      n.read = true;
+    }
+  }
+
+  function clearAll() {
+    notifications.value = [];
+  }
+
+  const unreadCount = () => notifications.value.filter(n => !n.read).length;
+
+  return { notifications, add, upsert, dismiss, markAllRead, clearAll, unreadCount };
+}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -2101,7 +2101,7 @@ thead th.active-sort .sort-arrow { opacity: 1; }
 
 /* 列宽 */
 .models-th-check { width: 36px; text-align: center !important; padding: 8px 0 !important; }
-.models-th-name { width: auto; }
+.models-th-name { max-width: 320px; }
 .models-th-provider { width: 120px; }
 .models-th-price { width: 120px; text-align: right !important; }
 .models-th-action { width: 32px; }
@@ -2121,8 +2121,10 @@ thead th.active-sort .sort-arrow { opacity: 1; }
 .models-td-name {
   font-family: var(--font-mono);
   font-size: 12px;
+  max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .models-td-provider { color: var(--text-secondary); font-size: 12px; }
 .models-td-price { text-align: right; font-size: 12px; }

--- a/frontend/src/views/ModelsView.vue
+++ b/frontend/src/views/ModelsView.vue
@@ -90,8 +90,17 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           <input class="form-input" v-model="libSearch" placeholder="搜索模型名…" @input="debouncedLoadLibrary" autocomplete="off">
         </div>
-        <div class="search-input-wrap" style="max-width:200px">
-          <input class="form-input" v-model="libVendor" placeholder="按厂商过滤…" @input="debouncedLoadLibrary" autocomplete="off">
+        <div class="combobox" style="max-width:200px" ref="libVendorRef">
+          <svg class="combobox-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          <input class="form-input" v-model="libVendorSearch" placeholder="按厂商过滤…" @focus="libVendorDropOpen = true" @input="libVendorDropOpen = true" autocomplete="off" style="padding-left:32px">
+          <button class="combobox-toggle" @click="libVendorDropOpen = !libVendorDropOpen">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 4.5l3 3 3-3"/></svg>
+          </button>
+          <div class="combobox-dropdown" v-show="libVendorDropOpen">
+            <div class="combobox-option" :class="{ active: libVendor === '' }" @mousedown.prevent="selectLibVendor('')">全部厂商</div>
+            <div v-for="v in filteredLibVendors" :key="v.id" class="combobox-option" :class="{ active: libVendor === v.id }" @mousedown.prevent="selectLibVendor(v.id)">{{ v.name }}</div>
+            <div class="combobox-empty" v-if="!filteredLibVendors.length && libVendorSearch">无匹配厂商</div>
+          </div>
         </div>
         <span class="models-count" style="margin-left:auto">共 {{ libTotal }} 个模型</span>
       </div>
@@ -279,10 +288,27 @@ async function saveMyModels() {
 const libLoading = ref(false);
 const libSearch = ref('');
 const libVendor = ref('');
+const libVendorSearch = ref('');
+const libVendorDropOpen = ref(false);
+const libVendorRef = ref(null);
 const libModels = ref([]);
 const libTotal = ref(0);
 const libPage = ref(1);
 const libPageSize = 50;
+
+const filteredLibVendors = computed(() => {
+  const q = libVendorSearch.value.toLowerCase().trim();
+  if (!q) return vendors.value;
+  return vendors.value.filter(v => v.name.toLowerCase().includes(q) || v.id.toLowerCase().includes(q));
+});
+
+function selectLibVendor(vendorId) {
+  libVendor.value = vendorId;
+  libVendorSearch.value = vendorId ? (vendors.value.find(v => v.id === vendorId)?.name || vendorId) : '';
+  libVendorDropOpen.value = false;
+  libPage.value = 1;
+  loadLibrary();
+}
 
 let libTimer = null;
 function debouncedLoadLibrary() {
@@ -375,6 +401,15 @@ onMounted(async () => {
 
 .models-panel {
   animation: fadeIn 0.15s ease;
+}
+
+.combobox-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
 }
 
 @keyframes fadeIn {

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -34,11 +34,11 @@ def test_get_builtin_models_returns_default_seed(tmp_path):
     models = mgr.get_builtin_models()
 
     assert isinstance(models, list)
-    assert len(models) >= 9
+    assert len(models) >= 8
     ids = [m["id"] for m in models]
     assert any("claude" in mid for mid in ids)
     assert any("gpt" in mid for mid in ids)
-    assert any("deepseek" in mid for mid in ids)
+    assert any("gemini" in mid for mid in ids)
 
     for m in models:
         assert "id" in m


### PR DESCRIPTION
## Summary
### 消息中心
- 新增 NotificationCenter 铃铛组件，常驻在 header 的"执行中"右边、头像左边
- 未读通知显示红色 badge，点击展开下拉面板查看所有完成通知
- done-toast 浮层已移除，通知逻辑抽到 useNotifications composable

### 模型管理
- 模型库"按厂商过滤"从文本输入改为 combobox 下拉菜单，风格与其他 combobox 一致
- 模型名列宽限制为 320px，超长名称 ellipsis 截断
- DEFAULT_MODELS 精简为 8 个：Opus 4.6, Sonnet 4.6, Haiku 4.5, GPT-5.4, GPT-5.3-codex, GPT-5.2, Gemini 3 Pro Preview, Gemini 3 Flash Lite Preview

## Test plan
- [x] 前端构建成功
- [x] 114 个测试全部通过