### PR TITLE
fix: 模型库厂商过滤动态化 + 下拉关闭修复

### DIFF
--- a/app/pricing.py
+++ b/app/pricing.py
@@ -186,6 +186,17 @@ class PricingService:
             "page_size": page_size,
         }
 
+    def get_providers(self) -> list[str]:
+        """从 LiteLLM 缓存中提取所有去重的 provider 列表"""
+        if not self._cache:
+            return []
+        providers = set()
+        for info in self._cache.values():
+            p = info.get("litellm_provider", "")
+            if p:
+                providers.add(p)
+        return sorted(providers)
+
     @staticmethod
     def _format_model_list(items: list) -> list[dict]:
         """格式化模型列表，用于 API 返回"""

--- a/app/server.py
+++ b/app/server.py
@@ -1527,6 +1527,13 @@ async def pricing_library(
     return pricing_service.get_library(search=search, vendor=vendor, page=page, page_size=page_size)
 
 
+@app.get("/api/pricing/providers")
+async def pricing_providers(user: dict = Depends(get_current_user)):
+    """返回 LiteLLM 中所有去重的 provider 列表"""
+    from app.pricing import pricing_service
+    return {"providers": pricing_service.get_providers()}
+
+
 @app.post("/api/pricing/refresh")
 async def pricing_refresh(user: dict = Depends(require_admin)):
     """管理员手动刷新价格数据"""

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -91,6 +91,7 @@ export const getModels = (baseUrl, apiKey) =>
 
 // Pricing / Model Config
 export const getVendors = () => api('/api/pricing/vendors');
+export const getProviders = () => api('/api/pricing/providers');
 export const getModelsConfig = () => api('/api/pricing/models-config');
 export const putModelsConfig = (data) =>
   api('/api/pricing/models-config', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });

--- a/frontend/src/views/ModelsView.vue
+++ b/frontend/src/views/ModelsView.vue
@@ -98,7 +98,7 @@
           </button>
           <div class="combobox-dropdown" v-show="libVendorDropOpen">
             <div class="combobox-option" :class="{ active: libVendor === '' }" @mousedown.prevent="selectLibVendor('')">全部厂商</div>
-            <div v-for="v in filteredLibVendors" :key="v.id" class="combobox-option" :class="{ active: libVendor === v.id }" @mousedown.prevent="selectLibVendor(v.id)">{{ v.name }}</div>
+            <div v-for="p in filteredLibVendors" :key="p" class="combobox-option" :class="{ active: libVendor === p }" @mousedown.prevent="selectLibVendor(p)">{{ p }}</div>
             <div class="combobox-empty" v-if="!filteredLibVendors.length && libVendorSearch">无匹配厂商</div>
           </div>
         </div>
@@ -149,8 +149,8 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { getModelsConfig, putModelsConfig, getLibrary, getVendors } from '../api';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { getModelsConfig, putModelsConfig, getLibrary, getVendors, getProviders } from '../api';
 import { toast } from '../composables/useToast';
 
 const activeTab = ref('my');
@@ -296,15 +296,18 @@ const libTotal = ref(0);
 const libPage = ref(1);
 const libPageSize = 50;
 
+// LiteLLM providers（从后端动态获取）
+const libProviders = ref([]);
+
 const filteredLibVendors = computed(() => {
   const q = libVendorSearch.value.toLowerCase().trim();
-  if (!q) return vendors.value;
-  return vendors.value.filter(v => v.name.toLowerCase().includes(q) || v.id.toLowerCase().includes(q));
+  if (!q) return libProviders.value;
+  return libProviders.value.filter(p => p.toLowerCase().includes(q));
 });
 
 function selectLibVendor(vendorId) {
   libVendor.value = vendorId;
-  libVendorSearch.value = vendorId ? (vendors.value.find(v => v.id === vendorId)?.name || vendorId) : '';
+  libVendorSearch.value = vendorId || '';
   libVendorDropOpen.value = false;
   libPage.value = 1;
   loadLibrary();
@@ -354,6 +357,8 @@ function addFromLibrary(model) {
 }
 
 // ---- Init ----
+let clickOutsideHandler = null;
+
 onMounted(async () => {
   try {
     const [configRes, vendorsRes] = await Promise.all([
@@ -366,6 +371,22 @@ onMounted(async () => {
     toast('加载失败: ' + e.message, 'error');
   }
   myLoading.value = false;
+
+  // 异步加载 LiteLLM providers（不阻塞页面）
+  getProviders().then(res => {
+    libProviders.value = res.providers || [];
+  }).catch(() => {});
+
+  clickOutsideHandler = (e) => {
+    if (libVendorRef.value && !libVendorRef.value.contains(e.target)) {
+      libVendorDropOpen.value = false;
+    }
+  };
+  document.addEventListener('click', clickOutsideHandler);
+});
+
+onUnmounted(() => {
+  if (clickOutsideHandler) document.removeEventListener('click', clickOutsideHandler);
 });
 </script>
 


### PR DESCRIPTION
## Summary
- 模型库"按厂商过滤"下拉列表从写死的 DEFAULT_VENDORS 改为从 LiteLLM 缓存动态提取所有 provider
- 新增 `GET /api/pricing/providers` 端点
- 修复厂商下拉框点击外部不自动收回的问题

## Test plan
- [x] 前端构建成功
- [x] 114 个测试全部通过