### PR TITLE
feat: 连通性验证统一 + 模型管理整改 + 6h 趋势图修复

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -32,7 +32,6 @@ export const deleteProfileApi = (name) => api(`/api/profiles/${encodeURIComponen
 export const startBenchApi = (data) => api('/api/bench/start', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
 export const stopBenchApi = () => api('/api/bench/stop', { method: 'POST' });
 export const getBenchStatus = () => api('/api/bench/status');
-export const dryRunApi = (data) => api('/api/bench/dry-run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
 export const startMultiBenchApi = (data) => api('/api/bench/start-multi', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
 export const getMultiBenchStatus = (groupId) => api(`/api/bench/status-multi/${encodeURIComponent(groupId)}`);
 export const getRunningTasks = () => api('/api/bench/running');

--- a/frontend/src/components/ConnectivityProgress.vue
+++ b/frontend/src/components/ConnectivityProgress.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="connectivity-progress" v-if="running || result">
+    <!-- 运行中：进度面板 -->
+    <div class="progress-panel" :class="{ active: running }" v-show="running">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">连通性验证中...</div>
+        </div>
+        <div class="progress-bar-wrap">
+          <div class="progress-bar" :style="barStyle"></div>
+        </div>
+        <div class="progress-stats">
+          <div class="progress-stat">
+            <div class="progress-stat-value">{{ progress.done }}</div>
+            <div class="progress-stat-label">已完成</div>
+          </div>
+          <div class="progress-stat">
+            <div class="progress-stat-value" style="color:var(--success)">{{ progress.success }}</div>
+            <div class="progress-stat-label">成功</div>
+          </div>
+          <div class="progress-stat">
+            <div class="progress-stat-value" style="color:var(--danger)">{{ progress.failed }}</div>
+            <div class="progress-stat-label">失败</div>
+          </div>
+          <div class="progress-stat">
+            <div class="progress-stat-value">{{ progress.elapsed + 's' }}</div>
+            <div class="progress-stat-label">耗时</div>
+          </div>
+        </div>
+        <div class="progress-log" ref="logRef">
+          <div v-for="(log, i) in logs" :key="i" v-html="log"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 完成后：结果指标卡片 -->
+    <div class="connectivity-result" v-if="!running && result">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">
+            <span v-if="!error" style="color:var(--success)">&#10003;</span>
+            <span v-else style="color:var(--danger)">&#10007;</span>
+            连通性验证{{ error ? '失败' : '通过' }}
+          </div>
+          <button class="btn btn-ghost btn-sm" @click="$emit('dismiss')">关闭</button>
+        </div>
+        <div class="connectivity-metrics" v-if="result.percentiles || result.summary">
+          <div class="connectivity-metric">
+            <span class="connectivity-metric-label">TTFT</span>
+            <span class="connectivity-metric-value">{{ fmtTime(result.percentiles?.TTFT?.P50) }}</span>
+          </div>
+          <div class="connectivity-metric">
+            <span class="connectivity-metric-label">TPOT</span>
+            <span class="connectivity-metric-value">{{ fmtTime(result.percentiles?.TPOT?.P50) }}</span>
+          </div>
+          <div class="connectivity-metric">
+            <span class="connectivity-metric-label">E2E</span>
+            <span class="connectivity-metric-value">{{ fmtTime(result.percentiles?.E2E?.P50) }}</span>
+          </div>
+          <div class="connectivity-metric">
+            <span class="connectivity-metric-label">Token/s</span>
+            <span class="connectivity-metric-value">{{ fmtNum(result.summary?.token_throughput_tps, 0) }}</span>
+          </div>
+          <div class="connectivity-metric">
+            <span class="connectivity-metric-label">成功率</span>
+            <span class="connectivity-metric-value">{{ fmtPct(result.summary?.success_rate) }}</span>
+          </div>
+        </div>
+        <div class="progress-log" v-if="logs.length" ref="logRef" style="margin-top:12px">
+          <div v-for="(log, i) in logs" :key="i" v-html="log"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch, nextTick, ref } from 'vue';
+import { fmtTime, fmtPct, fmtNum } from '../utils/formatters.js';
+
+const props = defineProps({
+  running: { type: Boolean, default: false },
+  progress: { type: Object, default: () => ({ done: 0, total: 0, success: 0, failed: 0, elapsed: 0, rate: '-' }) },
+  logs: { type: Array, default: () => [] },
+  result: { type: Object, default: null },
+  error: { type: String, default: null },
+});
+
+defineEmits(['dismiss']);
+
+const logRef = ref(null);
+
+const barStyle = computed(() => {
+  const pct = props.progress.total > 0
+    ? (props.progress.done / props.progress.total * 100).toFixed(1)
+    : 0;
+  return `width:${pct}%`;
+});
+
+watch(() => props.logs, () => {
+  nextTick(() => {
+    if (logRef.value) logRef.value.scrollTop = logRef.value.scrollHeight;
+  });
+}, { deep: true });
+</script>
+
+<style scoped>
+.connectivity-progress {
+  margin-top: 16px;
+}
+
+.connectivity-result .card {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+}
+
+.connectivity-result .card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.connectivity-result .card-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.connectivity-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+}
+
+.connectivity-metric {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.connectivity-metric-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.connectivity-metric-value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+</style>

--- a/frontend/src/components/ConnectivityProgress.vue
+++ b/frontend/src/components/ConnectivityProgress.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="connectivity-progress" v-if="running || result">
+  <div class="connectivity-progress" v-if="running || result || error">
     <!-- 运行中：进度面板 -->
-    <div class="progress-panel" :class="{ active: running }" v-show="running">
+    <div class="progress-panel" :class="{ active: running }">
       <div class="card">
         <div class="card-header">
           <div class="card-title">连通性验证中...</div>
@@ -34,7 +34,7 @@
     </div>
 
     <!-- 完成后：结果指标卡片 -->
-    <div class="connectivity-result" v-if="!running && result">
+    <div class="connectivity-result" v-if="!running && (result || error)">
       <div class="card">
         <div class="card-header">
           <div class="card-title">
@@ -44,7 +44,7 @@
           </div>
           <button class="btn btn-ghost btn-sm" @click="$emit('dismiss')">关闭</button>
         </div>
-        <div class="connectivity-metrics" v-if="result.percentiles || result.summary">
+        <div class="connectivity-metrics" v-if="result && (result.percentiles || result.summary)">
           <div class="connectivity-metric">
             <span class="connectivity-metric-label">TTFT</span>
             <span class="connectivity-metric-value">{{ fmtTime(result.percentiles?.TTFT?.P50) }}</span>

--- a/frontend/src/components/SiteConfigTab.vue
+++ b/frontend/src/components/SiteConfigTab.vue
@@ -54,8 +54,8 @@
           <button class="btn btn-primary" @click="saveProfile()" :disabled="!canSave()">
             {{ formDirty ? '更新配置' : '保存配置' }}
           </button>
-          <button class="btn btn-ghost" @click="dryRunTest()" :disabled="!canTest()" v-if="form.base_url && form.api_key && form.models.length">
-            连通性测试
+          <button class="btn btn-ghost" @click="runConnTest()" :disabled="!canTest()" v-if="form.base_url && form.api_key && form.models.length">
+            连通性验证
           </button>
         </div>
         <div class="site-config-actions-right">
@@ -70,6 +70,15 @@
           </button>
         </div>
       </div>
+
+      <ConnectivityProgress
+        :running="connTest.running.value"
+        :progress="connTest.progress.value"
+        :logs="connTest.logs.value"
+        :result="connTest.result.value"
+        :error="connTest.error.value"
+        @dismiss="connTest.reset()"
+      />
     </div>
   </div>
 </template>
@@ -79,6 +88,8 @@ import { ref, watch } from 'vue';
 import { api } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import ModelSelector from './ModelSelector.vue';
+import ConnectivityProgress from './ConnectivityProgress.vue';
+import { useConnectivityTest } from '../composables/useConnectivityTest.js';
 
 const props = defineProps({
   profile: { type: Object, required: true },
@@ -96,9 +107,6 @@ const showApiKey = ref(false);
 const confirmDelete = ref(false);
 const formDirty = ref(false);
 const savedConfig = ref(null);
-
-// ---- Connectivity test ----
-const testing = ref(false);
 
 // ---- Init form from profile ----
 function initForm() {
@@ -149,13 +157,25 @@ function canSave() {
   );
 }
 
+const connTest = useConnectivityTest();
+
 function canTest() {
   return Boolean(
     form.value.base_url.trim() &&
     form.value.api_key.trim() &&
     form.value.models.length > 0 &&
-    !testing.value
+    !connTest.running.value
   );
+}
+
+function runConnTest() {
+  if (!canTest()) return;
+  connTest.start({
+    base_url: form.value.base_url,
+    api_key: form.value.api_key,
+    model: form.value.models[0] || '',
+    custom_endpoint: form.value.custom_endpoint,
+  });
 }
 
 // ---- Actions ----
@@ -186,37 +206,6 @@ async function saveProfile() {
     snapshotConfig();
   } catch (e) {
     toast('保存失败: ' + e.message, 'error');
-  }
-}
-
-async function dryRunTest() {
-  if (!canTest()) return;
-  testing.value = true;
-  try {
-    const res = await api('/api/bench/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        base_url: form.value.base_url,
-        api_key: form.value.api_key,
-        model: form.value.models[0] || '',
-        custom_endpoint: form.value.custom_endpoint,
-        concurrency_levels: [1],
-        requests_per_level: 1,
-        mode: 'burst',
-        max_tokens: 512,
-        timeout: 120,
-        duration: 120,
-        system_prompt: 'You are a helpful assistant.',
-        user_prompt: 'Say hello.',
-      }),
-    });
-    if (res.error) { toast(res.error, 'error'); return; }
-    toast('连通性测试已启动', 'info');
-  } catch (e) {
-    toast('测试失败: ' + e.message, 'error');
-  } finally {
-    testing.value = false;
   }
 }
 

--- a/frontend/src/components/SiteTestTab.vue
+++ b/frontend/src/components/SiteTestTab.vue
@@ -120,10 +120,19 @@
           <span v-if="selectedModels.length > 1" style="font-weight:400;color:rgba(255,255,255,0.8)">({{ selectedModels.length }} 个模型)</span>
         </button>
         <button class="btn btn-danger" v-show="running" @click="stopBench()">停止</button>
-        <button class="btn btn-ghost" v-show="!running" @click="dryRun()" :disabled="!selectedModels.length">
+        <button class="btn btn-ghost" v-show="!running && !connTest.running.value" @click="runConnTest()" :disabled="!selectedModels.length">
           连通性验证 <span style="font-weight:400;color:var(--text-tertiary)">(单请求)</span>
         </button>
       </div>
+
+      <ConnectivityProgress
+        :running="connTest.running.value"
+        :progress="connTest.progress.value"
+        :logs="connTest.logs.value"
+        :result="connTest.result.value"
+        :error="connTest.error.value"
+        @dismiss="connTest.reset()"
+      />
 
       <!-- Progress Panel -->
       <div class="progress-panel" :class="{ active: running }" v-show="running">
@@ -266,6 +275,8 @@ import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { api } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import { useBenchSSE } from '../composables/useBenchSSE.js';
+import ConnectivityProgress from './ConnectivityProgress.vue';
+import { useConnectivityTest } from '../composables/useConnectivityTest.js';
 import { renderResultDetail } from '../utils/resultDetail.js';
 import { fmtTime, fmtPct, fmtNum, escHtml } from '../utils/formatters.js';
 
@@ -365,6 +376,7 @@ const running = ref(false);
 const progress = ref({ done: 0, total: 0, success: 0, failed: 0, elapsed: 0, rate: '-' });
 const logs = ref([]);
 const benchSSE = useBenchSSE();
+const connTest = useConnectivityTest();
 const elapsedTimer = ref(null);
 let benchStartTime = 0;
 
@@ -475,46 +487,18 @@ async function startBench() {
   }
 }
 
-async function dryRun() {
+function runConnTest() {
   if (!selectedModels.value.length) {
     toast('请至少选择一个模型', 'info');
     return;
   }
-  // Use first selected model
-  const model = selectedModels.value[0];
-  const config = buildConfig(model);
-  config.concurrency_levels = [1];
-  config.requests_per_level = 1;
-  config.mode = 'burst';
-
-  running.value = true;
-  logs.value = [];
-  modelResults.value = [{ model, result: null, running: true }];
-  currentModelIndex.value = 0;
-
-  logLine(`<span class="info">连通性验证: ${escHtml(model)}</span>`);
-
-  try {
-    const res = await api('/api/bench/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(config),
-    });
-    if (res.error) {
-      toast(res.error, 'error');
-      logLine(`<span class="fail">${escHtml(res.error)}</span>`);
-      running.value = false;
-      modelResults.value[0].running = false;
-      return;
-    }
-    await runWithSSE(model);
-  } catch (e) {
-    toast('失败: ' + e.message, 'error');
-    logLine(`<span class="fail">${escHtml(e.message)}</span>`);
-  }
-  running.value = false;
-  modelResults.value[0].running = false;
-  currentModelIndex.value = -1;
+  connTest.start({
+    base_url: props.profile.base_url,
+    api_key: props.profile.api_key_display || props.profile.api_key,
+    model: selectedModels.value[0],
+    provider: props.profile.provider || '',
+    custom_endpoint: props.profile.custom_endpoint || false,
+  });
 }
 
 function runWithSSE(modelName) {

--- a/frontend/src/components/SiteTrendsTab.vue
+++ b/frontend/src/components/SiteTrendsTab.vue
@@ -331,7 +331,10 @@ function renderLatencyChart() {
   const canvas = latencyCanvas.value;
   if (!canvas) return;
 
-  const { labels, items } = aggregateToFixedPoints(trend, 144, timeRangeStore.hours);
+  // 桶数随时间范围缩放，保持 ~10 min/桶 的密度（与 24h 一致）
+  const hours = timeRangeStore.hours;
+  const targetPts = hours ? Math.min(144, Math.max(36, hours * 6)) : 144;
+  const { labels, items } = aggregateToFixedPoints(trend, targetPts, hours);
 
   latencyChart = new Chart(canvas, {
     type: 'line',
@@ -345,7 +348,7 @@ function renderLatencyChart() {
           borderColor: '#3B7DD6',
           backgroundColor: '#3B7DD618',
           borderWidth: 2,
-          pointRadius: trend.length <= 50 ? 3 : 0,
+          pointRadius: 0,
           tension: 0.3,
           fill: true,
           spanGaps: false,
@@ -356,7 +359,7 @@ function renderLatencyChart() {
           borderColor: '#E85D26',
           backgroundColor: '#E85D2618',
           borderWidth: 2,
-          pointRadius: trend.length <= 50 ? 3 : 0,
+          pointRadius: 0,
           tension: 0.3,
           fill: true,
           spanGaps: false,
@@ -401,7 +404,9 @@ function renderQualityChart() {
   const canvas = qualityCanvas.value;
   if (!canvas) return;
 
-  const { labels, items } = aggregateToFixedPoints(trend, 144, timeRangeStore.hours);
+  const hours = timeRangeStore.hours;
+  const targetPts = hours ? Math.min(144, Math.max(36, hours * 6)) : 144;
+  const { labels, items } = aggregateToFixedPoints(trend, targetPts, hours);
   const failureData = items.map(r => r?.avg_success_rate != null ? (100 - r.avg_success_rate) : null);
 
   qualityChart = new Chart(canvas, {
@@ -416,7 +421,7 @@ function renderQualityChart() {
           borderColor: '#2D8B55',
           backgroundColor: '#2D8B5518',
           borderWidth: 2,
-          pointRadius: trend.length <= 50 ? 3 : 0,
+          pointRadius: 0,
           tension: 0.3,
           fill: true,
           yAxisID: 'y',
@@ -428,7 +433,7 @@ function renderQualityChart() {
           borderColor: '#E85D26',
           backgroundColor: '#E85D2618',
           borderWidth: 2,
-          pointRadius: trend.length <= 50 ? 3 : 0,
+          pointRadius: 0,
           tension: 0.3,
           fill: true,
           yAxisID: 'y1',

--- a/frontend/src/composables/useConnectivityTest.js
+++ b/frontend/src/composables/useConnectivityTest.js
@@ -120,7 +120,7 @@ export function useConnectivityTest() {
             break;
           case 'bench:error':
             cleanup();
-            error.value = d.error;
+            error.value = String(d.error);
             logLine(`<span class="fail">错误: ${escHtml(d.error)}</span>`);
             resolve();
             break;
@@ -129,7 +129,7 @@ export function useConnectivityTest() {
 
       elapsedTimer = setInterval(() => {
         if (running.value && startTime) {
-          progress.value.elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+          progress.value.elapsed = Math.round((Date.now() - startTime) / 100) / 10;
         }
       }, 1000);
     });

--- a/frontend/src/composables/useConnectivityTest.js
+++ b/frontend/src/composables/useConnectivityTest.js
@@ -1,0 +1,146 @@
+import { ref, onUnmounted } from 'vue';
+import { api } from '../api/index.js';
+import { useBenchSSE } from './useBenchSSE.js';
+import { toast } from './useToast.js';
+import { escHtml } from '../utils/formatters.js';
+
+export function useConnectivityTest() {
+  const running = ref(false);
+  const progress = ref({ done: 0, total: 0, success: 0, failed: 0, elapsed: 0, rate: '-' });
+  const logs = ref([]);
+  const result = ref(null);
+  const error = ref(null);
+
+  const benchSSE = useBenchSSE();
+  let elapsedTimer = null;
+  let startTime = 0;
+
+  function logLine(html) {
+    const time = new Date().toLocaleTimeString();
+    logs.value = [...logs.value, `[${time}] ${html}`];
+  }
+
+  function cleanup() {
+    benchSSE.disconnect();
+    if (elapsedTimer) {
+      clearInterval(elapsedTimer);
+      elapsedTimer = null;
+    }
+  }
+
+  function reset() {
+    running.value = false;
+    progress.value = { done: 0, total: 0, success: 0, failed: 0, elapsed: 0, rate: '-' };
+    logs.value = [];
+    result.value = null;
+    error.value = null;
+  }
+
+  async function start(config) {
+    reset();
+    running.value = true;
+
+    const model = config.model;
+    logLine(`<span class="info">连通性验证: ${escHtml(model)}</span>`);
+
+    try {
+      const res = await api('/api/bench/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          base_url: config.base_url,
+          api_key: config.api_key,
+          model,
+          provider: config.provider || '',
+          custom_endpoint: config.custom_endpoint || false,
+          concurrency_levels: [1],
+          requests_per_level: 1,
+          mode: 'burst',
+          max_tokens: 512,
+          timeout: 120,
+          duration: 120,
+          system_prompt: 'You are a helpful assistant.',
+          user_prompt: 'Say hello.',
+        }),
+      });
+
+      if (res.error) {
+        error.value = res.error;
+        toast(res.error, 'error');
+        logLine(`<span class="fail">${escHtml(res.error)}</span>`);
+        running.value = false;
+        return;
+      }
+
+      await waitForSSE(model);
+    } catch (e) {
+      error.value = e.message;
+      toast('连通性验证失败: ' + e.message, 'error');
+      logLine(`<span class="fail">${escHtml(e.message)}</span>`);
+    }
+    running.value = false;
+  }
+
+  function waitForSSE(modelName) {
+    return new Promise((resolve) => {
+      startTime = Date.now();
+      progress.value = { done: 0, total: 0, success: 0, failed: 0, elapsed: 0, rate: '-' };
+
+      benchSSE.connect((type, d) => {
+        switch (type) {
+          case 'bench:start':
+            logLine(`<span class="info">请求发送中...</span>`);
+            break;
+          case 'bench:progress':
+            progress.value = {
+              ...progress.value,
+              done: d.done,
+              success: d.success,
+              failed: d.failed,
+              total: d.total,
+              elapsed: d.elapsed,
+            };
+            if (d.elapsed > 0) progress.value.rate = (d.done / d.elapsed).toFixed(1);
+            break;
+          case 'bench:level_complete':
+            result.value = d.result;
+            logLine(`<span class="ok">验证完成</span>`);
+            break;
+          case 'bench:complete':
+            cleanup();
+            if (!error.value && result.value) {
+              toast('连通性验证通过', 'success');
+            }
+            resolve();
+            break;
+          case 'bench:stopped':
+            cleanup();
+            logLine(`<span class="fail">已停止</span>`);
+            resolve();
+            break;
+          case 'bench:error':
+            cleanup();
+            error.value = d.error;
+            logLine(`<span class="fail">错误: ${escHtml(d.error)}</span>`);
+            resolve();
+            break;
+        }
+      });
+
+      elapsedTimer = setInterval(() => {
+        if (running.value && startTime) {
+          progress.value.elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        }
+      }, 1000);
+    });
+  }
+
+  function stop() {
+    cleanup();
+    running.value = false;
+  }
+
+  onUnmounted(() => cleanup());
+
+  return { running, progress, logs, result, error, start, stop, reset };
+}

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -115,11 +115,19 @@
           <button class="btn btn-primary" @click="saveProfile()">
             {{ profileMode === 'new' ? '保存配置' : '更新配置' }}
           </button>
-          <button class="btn btn-ghost" @click="dryRunTest()" v-if="profileMode === 'selected' && form.base_url && form.api_key && form.models.length">
+          <button class="btn btn-ghost" @click="runConnTest()" :disabled="connTest.running.value" v-if="profileMode === 'selected' && form.base_url && form.api_key && form.models.length">
             连通性验证
           </button>
         </div>
       </div>
+      <ConnectivityProgress
+        :running="connTest.running.value"
+        :progress="connTest.progress.value"
+        :logs="connTest.logs.value"
+        :result="connTest.result.value"
+        :error="connTest.error.value"
+        @dismiss="connTest.reset()"
+      />
 
       <div v-if="profiles.length === 0 && profileMode !== 'new'" style="text-align:center;color:var(--text-tertiary);padding:40px 20px">
         <div style="font-size:14px;margin-bottom:8px">还没有连接配置</div>
@@ -132,10 +140,21 @@
 <script setup>
 import { ref, computed, watch, onMounted, nextTick } from 'vue';
 import { api } from '../api/index.js';
-import { useAppStore } from '../stores/app.js';
 import { toast } from '../composables/useToast.js';
+import ConnectivityProgress from '../components/ConnectivityProgress.vue';
+import { useConnectivityTest } from '../composables/useConnectivityTest.js';
 
-const store = useAppStore();
+const connTest = useConnectivityTest();
+
+function runConnTest() {
+  connTest.start({
+    base_url: form.value.base_url,
+    api_key: form.value.api_key,
+    model: form.value.models[0] || '',
+    provider: form.value.provider,
+    custom_endpoint: form.value.custom_endpoint || false,
+  });
+}
 
 // ---- Template refs ----
 const renameInputRef = ref(null);
@@ -537,34 +556,6 @@ function profileHost(baseUrl) {
   }
 }
 
-async function dryRunTest() {
-  const token = localStorage.getItem('token');
-  if (!token) return;
-  try {
-    const res = await api('/api/bench/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        base_url: form.value.base_url,
-        api_key: form.value.api_key,
-        model: form.value.models[0] || '',
-        provider: form.value.provider,
-        custom_endpoint: form.value.custom_endpoint || false,
-        concurrency_levels: [1],
-        requests_per_level: 1,
-        mode: 'burst',
-        max_tokens: 512,
-        timeout: 120,
-        duration: 120,
-        system_prompt: 'You are a helpful assistant.',
-        user_prompt: 'Say hello.',
-      }),
-    });
-    if (res.error) { toast(res.error, 'error'); return; }
-    toast('连通性验证已启动', 'info');
-    store.switchTab('bench');
-  } catch (e) { toast('失败: ' + e.message, 'error'); }
-}
 
 // ---- Lifecycle ----
 onMounted(() => {


### PR DESCRIPTION
## Summary
- 连通性验证统一为 `useConnectivityTest` composable + `ConnectivityProgress` 组件，三个入口复用
- 模型管理整改：内置模型数据层、厂商/模型库 API、ModelSelector 通用组件
- 消息中心组件 + 通知弹窗分区
- Profile 支持完整 URL 模式（custom_endpoint）
- 6h 趋势图曲线不显示修复：动态桶数保持 ~10min/桶密度，统一 pointRadius

## Test plan
- [ ] 站点配置/单次任务/Profile 页面连通性测试正常
- [ ] 模型管理页面双 Tab 切换正常
- [ ] 新建站点弹窗模型选择正常
- [ ] 6h/24h/7d/全部 时间范围趋势图均正常渲染
- [ ] 定时任务创建和管理正常