### PR TITLE
fix: 定时清理已完成的内存任务，防止长期运行 OOM (#24)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,10 @@ JWT_SECRET = os.environ.get("JWT_SECRET", "")
 # 定时任务单次执行超时（秒），超时后自动释放锁防止卡死
 SCHEDULER_TASK_TIMEOUT = int(os.environ.get("SCHEDULER_TASK_TIMEOUT", "1800"))
 
+# 内存任务清理：每隔多久扫一次、完成后保留多久（grace，防止误删正在被 SSE 查看的任务）
+TASK_CLEANUP_INTERVAL = int(os.environ.get("TASK_CLEANUP_INTERVAL", "1800"))
+TASK_RETENTION_SECONDS = int(os.environ.get("TASK_RETENTION_SECONDS", "1800"))
+
 # E2E 测试模式：拦截出站 AI API 请求，返回模拟响应
 E2E_TEST_MODE = os.environ.get("E2E_TEST_MODE", "") == "1"
 

--- a/app/server.py
+++ b/app/server.py
@@ -75,6 +75,7 @@ class BenchTask:
     failed_count: int = 0
     total_count: int = 0
     start_time: float = 0.0
+    finished_at: float = 0.0  # 完成时间 (monotonic)，用于 cleanup grace 判定
     asyncio_task: Optional[asyncio.Task] = None
     result_filenames: list = field(default_factory=list)
     event_waiters: list = field(default_factory=list)  # asyncio.Event for SSE
@@ -193,11 +194,33 @@ class BenchTaskManager:
             if not group:
                 self._group_tasks.pop(task.group_id, None)
 
-    def cleanup_idle(self):
-        """清理已完成的任务，释放内存"""
-        to_remove = [tid for tid, t in self._tasks.items() if t.status == "idle" and t.asyncio_task is None]
+    def cleanup_idle(self, grace_seconds: float = 0.0, now: float | None = None):
+        """清理已完成的任务及其孤儿 run，释放内存。
+
+        只清理「真正完成（finished_at>0）且超过 grace 窗口」的 idle 任务，
+        避免误删刚完成（可能仍被 SSE 查看）或刚创建待启动（finished_at==0）的任务。
+
+        Args:
+            grace_seconds: 任务完成后至少保留多久才允许清理。
+            now: 当前 monotonic 时间，缺省取 time.monotonic()（参数化便于测试）。
+        """
+        ts = now if now is not None else time.monotonic()
+        to_remove = [
+            tid for tid, t in self._tasks.items()
+            if t.status == "idle" and t.asyncio_task is None
+            and t.finished_at > 0.0 and ts - t.finished_at >= grace_seconds
+        ]
         for tid in to_remove:
             self.remove_task(tid)
+        self._cleanup_orphan_runs()
+
+    def _cleanup_orphan_runs(self):
+        """移除已无任何在册 task 的 run，防止 _runs 字典无界增长。"""
+        for run_id in list(self._runs.keys()):
+            run = self._runs[run_id]
+            if not any(tid in self._tasks for tid in run.task_ids):
+                self._runs.pop(run_id, None)
+                self._group_tasks.pop(run_id, None)
 
 
 manager = BenchTaskManager()
@@ -452,11 +475,29 @@ async def _run_benchmark_task(config: dict, owner_id: int, task: BenchTask):
     finally:
         task.status = "idle"
         task.asyncio_task = None
+        task.finished_at = time.monotonic()
 
 
 # ---- App + Lifespan ----
 
 _scheduler = None
+
+
+async def _periodic_task_cleanup():
+    """后台循环：定期清理已完成的内存任务/run，防止常驻运行 OOM（issue #24）。"""
+    from app.config import TASK_CLEANUP_INTERVAL, TASK_RETENTION_SECONDS
+    while True:
+        try:
+            await asyncio.sleep(TASK_CLEANUP_INTERVAL)
+            before = len(manager._tasks)
+            manager.cleanup_idle(grace_seconds=TASK_RETENTION_SECONDS)
+            removed = before - len(manager._tasks)
+            if removed:
+                log.info("内存任务清理：移除 %d 个已完成任务，剩余 %d", removed, len(manager._tasks))
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            log.error("内存任务清理异常: %s", e)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -471,7 +512,14 @@ async def lifespan(app: FastAPI):
     from app.scheduler import TaskScheduler
     _scheduler = TaskScheduler()
     await _scheduler.start()
+
+    cleanup_task = asyncio.create_task(_periodic_task_cleanup())
     yield
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
     if _scheduler:
         await _scheduler.stop()
     await close_db()

--- a/tests/test_task_cleanup.py
+++ b/tests/test_task_cleanup.py
@@ -1,0 +1,93 @@
+"""测试 BenchTaskManager.cleanup_idle —— 防止已完成任务/run 在内存中无界堆积。
+
+回归 issue #24：cleanup_idle 此前从未被调用，且不清理 _runs，导致常驻数月后 OOM。
+"""
+
+import pytest
+
+from app.server import BenchTaskManager
+
+
+def _make_finished_task(mgr: BenchTaskManager, task_id: str, run_id: str,
+                        finished_at: float):
+    """构造一个已完成（idle + 无 asyncio_task + 带 finished_at）的任务。"""
+    task = mgr.create_task(task_id, owner_id=1, run_id=run_id, group_id=run_id)
+    task.status = "idle"
+    task.asyncio_task = None
+    task.finished_at = finished_at
+    return task
+
+
+def test_cleanup_removes_finished_task_and_orphan_run():
+    """已完成的任务及其孤儿 run 应被清理。"""
+    mgr = BenchTaskManager()
+    mgr.create_run("run-1", owner_id=1)
+    _make_finished_task(mgr, "task-1", "run-1", finished_at=100.0)
+
+    # grace=0、now 远大于 finished_at → 应清理
+    mgr.cleanup_idle(grace_seconds=0.0, now=1000.0)
+
+    assert mgr.get_task("task-1") is None, "已完成任务应被移除"
+    assert mgr.get_run("run-1") is None, "孤儿 run 应被移除"
+
+
+def test_cleanup_respects_grace_period():
+    """grace 窗口内刚完成的任务不应被误删（可能仍被 SSE 查看）。"""
+    mgr = BenchTaskManager()
+    mgr.create_run("run-1", owner_id=1)
+    _make_finished_task(mgr, "task-1", "run-1", finished_at=1000.0)
+
+    # now 距 finished_at 仅 10s，grace=1800s → 不应清理
+    mgr.cleanup_idle(grace_seconds=1800.0, now=1010.0)
+
+    assert mgr.get_task("task-1") is not None, "grace 内的任务不应被删"
+    assert mgr.get_run("run-1") is not None, "其 run 也应保留"
+
+    # 超过 grace 后应被清理
+    mgr.cleanup_idle(grace_seconds=1800.0, now=1000.0 + 1801.0)
+    assert mgr.get_task("task-1") is None
+    assert mgr.get_run("run-1") is None
+
+
+def test_cleanup_keeps_running_task_and_run():
+    """运行中的任务（有 asyncio_task / 非 idle）及其 run 必须保留。"""
+    mgr = BenchTaskManager()
+    mgr.create_run("run-1", owner_id=1)
+    task = mgr.create_task("task-1", owner_id=1, run_id="run-1", group_id="run-1")
+    task.status = "running"  # 运行中
+
+    mgr.cleanup_idle(grace_seconds=0.0, now=10_000.0)
+
+    assert mgr.get_task("task-1") is not None, "运行中的任务不能删"
+    assert mgr.get_run("run-1") is not None, "有活跃任务的 run 不能删"
+
+
+def test_cleanup_keeps_never_started_task():
+    """从未运行（finished_at==0）的 idle 任务不删，避免误删刚创建待启动的任务。"""
+    mgr = BenchTaskManager()
+    mgr.create_run("run-1", owner_id=1)
+    task = mgr.create_task("task-1", owner_id=1, run_id="run-1", group_id="run-1")
+    task.status = "idle"
+    task.asyncio_task = None
+    # finished_at 保持默认 0.0
+
+    mgr.cleanup_idle(grace_seconds=0.0, now=10_000.0)
+
+    assert mgr.get_task("task-1") is not None, "未完成（finished_at==0）的任务不应被删"
+
+
+def test_cleanup_mixed_only_removes_eligible():
+    """混合场景：只清理符合条件的，保留其余。"""
+    mgr = BenchTaskManager()
+    mgr.create_run("run-done", owner_id=1)
+    mgr.create_run("run-live", owner_id=1)
+    _make_finished_task(mgr, "t-done", "run-done", finished_at=100.0)
+    live = mgr.create_task("t-live", owner_id=1, run_id="run-live", group_id="run-live")
+    live.status = "running"
+
+    mgr.cleanup_idle(grace_seconds=0.0, now=5000.0)
+
+    assert mgr.get_task("t-done") is None
+    assert mgr.get_run("run-done") is None
+    assert mgr.get_task("t-live") is not None
+    assert mgr.get_run("run-live") is not None

--- a/tests/test_task_cleanup.py
+++ b/tests/test_task_cleanup.py
@@ -76,6 +76,24 @@ def test_cleanup_keeps_never_started_task():
     assert mgr.get_task("task-1") is not None, "未完成（finished_at==0）的任务不应被删"
 
 
+def test_cleanup_keeps_run_with_partially_completed_children():
+    """同一个 run 内一个子任务已完成、另一个仍在运行：run 与运行中子任务都不能删。
+
+    这是 _cleanup_orphan_runs 的 any(...) 判定最易写错的分支（多模型 run 部分完成）。
+    """
+    mgr = BenchTaskManager()
+    mgr.create_run("run-1", owner_id=1)
+    _make_finished_task(mgr, "t-done", "run-1", finished_at=100.0)
+    running = mgr.create_task("t-running", owner_id=1, run_id="run-1", group_id="run-1")
+    running.status = "running"
+
+    mgr.cleanup_idle(grace_seconds=0.0, now=5000.0)
+
+    assert mgr.get_task("t-done") is None, "已完成子任务应被清理"
+    assert mgr.get_task("t-running") is not None, "运行中子任务必须保留"
+    assert mgr.get_run("run-1") is not None, "仍有运行中子任务的 run 不能被删"
+
+
 def test_cleanup_mixed_only_removes_eligible():
     """混合场景：只清理符合条件的，保留其余。"""
     mgr = BenchTaskManager()


### PR DESCRIPTION
## Summary
- `cleanup_idle` 此前从未被调用，且不清理 `_runs`，常驻数月会内存无界增长直至 OOM
- 新增后台循环（lifespan 内），每 `TASK_CLEANUP_INTERVAL`（默认 30min）清理一次
- `cleanup_idle` 增加 grace period：只清理 `finished_at>0` 且超过保留窗口的 idle 任务，避免误删刚完成（可能仍被 SSE 查看）或刚创建待启动的任务
- 新增 `_cleanup_orphan_runs` 释放无活跃 task 的 run
- `BenchTask` 增加 `finished_at`，完成时记录
- 新增可配置项 `TASK_CLEANUP_INTERVAL` / `TASK_RETENTION_SECONDS`

Closes #24

## Test plan
- [x] 新增 tests/test_task_cleanup.py：清理/grace/保留/运行中保护/混合场景
- [x] 全量后端测试 215 passed
- [ ] 人工确认：长期运行后内存稳定（部署后观察）