### PR TITLE
feat: 定时拨测失败告警闭环（飞书）(#30)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -117,6 +117,10 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     next_run_at     TEXT,
     locked_until    TEXT,
     run_count       INTEGER NOT NULL DEFAULT 0,
+    alert_webhook   TEXT NOT NULL DEFAULT '',
+    alert_threshold INTEGER NOT NULL DEFAULT 90,
+    alert_enabled   INTEGER NOT NULL DEFAULT 0,
+    alert_state     TEXT NOT NULL DEFAULT 'ok',
     created_at      TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -212,6 +216,10 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     next_run_at     TIMESTAMPTZ,
     locked_until    TIMESTAMPTZ,
     run_count       INTEGER NOT NULL DEFAULT 0,
+    alert_webhook   TEXT NOT NULL DEFAULT '',
+    alert_threshold INTEGER NOT NULL DEFAULT 90,
+    alert_enabled   BOOLEAN NOT NULL DEFAULT FALSE,
+    alert_state     TEXT NOT NULL DEFAULT 'ok',
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -297,6 +305,27 @@ async def init_db():
                 "ALTER TABLE results ADD COLUMN IF NOT EXISTS run_id TEXT NOT NULL DEFAULT ''",
                 "ALTER TABLE results ADD COLUMN IF NOT EXISTS task_id TEXT NOT NULL DEFAULT ''",
                 "ALTER TABLE results ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual'",
+            ]:
+                await conn.execute(text(col_def))
+
+        # scheduled_tasks 告警列：对已有表 ALTER TABLE
+        if _is_sqlite:
+            for col_def in [
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_webhook TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_threshold INTEGER NOT NULL DEFAULT 90",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_enabled INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_state TEXT NOT NULL DEFAULT 'ok'",
+            ]:
+                try:
+                    await conn.execute(text(col_def))
+                except Exception:
+                    pass  # 列已存在则忽略
+        else:
+            for col_def in [
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_webhook TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_threshold INTEGER NOT NULL DEFAULT 90",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_state TEXT NOT NULL DEFAULT 'ok'",
             ]:
                 await conn.execute(text(col_def))
 
@@ -1073,14 +1102,18 @@ async def save_settings(user_id: int, benchmark: dict, output_dir: str = "./resu
 
 async def create_scheduled_task(user_id: int, name: str, profile_ids: list,
                                  configs_json: dict, schedule_type: str,
-                                 schedule_value: str) -> int:
+                                 schedule_value: str, alert_webhook: str = "",
+                                 alert_threshold: int = 90,
+                                 alert_enabled: bool = False) -> int:
     async with engine.begin() as conn:
         cur = await conn.execute(
             text("""INSERT INTO scheduled_tasks (user_id, name, profile_ids, configs_json,
-                    schedule_type, schedule_value)
-                   VALUES (:uid, :name, :pids, :cj, :st, :sv)"""),
+                    schedule_type, schedule_value, alert_webhook, alert_threshold, alert_enabled)
+                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :aw, :at, :ae)"""),
             {"uid": user_id, "name": name, "pids": json.dumps(profile_ids),
-             "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value},
+             "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value,
+             "aw": alert_webhook, "at": alert_threshold,
+             "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled)},
         )
         if _is_sqlite:
             return cur.lastrowid
@@ -1143,7 +1176,8 @@ async def get_scheduled_task(task_id: int) -> Optional[dict]:
 async def update_scheduled_task(task_id: int, **fields):
     async with engine.begin() as conn:
         allowed = {"name", "profile_ids", "configs_json", "schedule_type",
-                   "schedule_value", "status", "last_run_at", "next_run_at", "run_count"}
+                   "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
+                   "alert_webhook", "alert_threshold", "alert_enabled", "alert_state"}
         set_parts = []
         values = {"id": task_id}
         for k, v in fields.items():

--- a/app/db.py
+++ b/app/db.py
@@ -649,6 +649,29 @@ async def save_result(user_id: int, test_id: str, filename: str, timestamp: str,
         )
 
 
+async def get_run_success_rate(run_ids: list) -> tuple:
+    """聚合给定 run 的全部 result 行的 (success_count, total_requests)。返回 (success, total)。"""
+    if not run_ids:
+        return (0, 0)
+    placeholders = ",".join(f":r{i}" for i in range(len(run_ids)))
+    params = {f"r{i}": rid for i, rid in enumerate(run_ids)}
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text(f"SELECT summary_json FROM results WHERE run_id IN ({placeholders})"),
+            params,
+        )
+        rows = cur.fetchall()
+    success = total = 0
+    for row in rows:
+        try:
+            s = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        success += int(s.get("success_count") or 0)
+        total += int(s.get("total_requests") or 0)
+    return (success, total)
+
+
 def _row_to_result_dict(row, lightweight: bool = False) -> dict:
     d = dict(row._mapping)
     d["config"] = json.loads(d["config_json"])

--- a/app/db.py
+++ b/app/db.py
@@ -1210,6 +1210,8 @@ async def update_scheduled_task(task_id: int, **fields):
                     v = json.dumps(v)
                 elif k == "configs_json" and isinstance(v, dict):
                     v = json.dumps(v)
+                elif k == "alert_enabled" and _is_sqlite:
+                    v = 1 if v else 0  # SQLite 布尔归一，与 create_scheduled_task 一致
                 values[k] = v
         if not set_parts:
             return

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""告警通知模块：状态机判定 + 飞书卡片 + webhook 发送（SSRF 限飞书域名）。"""
+
+import logging
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+import aiohttp
+
+log = logging.getLogger("notifier")
+
+ALERT_OK = "ok"
+ALERT_ALERTING = "alerting"
+FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
+
+
+def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> Tuple[str, Optional[str]]:
+    """返回 (新状态, 动作)。动作 ∈ {None, 'alert', 'recover'}。仅状态翻转时给动作。"""
+    abnormal = success_rate < threshold
+    if abnormal and prev_state != ALERT_ALERTING:
+        return ALERT_ALERTING, "alert"
+    if not abnormal and prev_state == ALERT_ALERTING:
+        return ALERT_OK, "recover"
+    return prev_state, None

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -22,3 +22,24 @@ def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> Tupl
     if not abnormal and prev_state == ALERT_ALERTING:
         return ALERT_OK, "recover"
     return prev_state, None
+
+
+def _safe_host(url: str) -> str:
+    """日志脱敏：只取 host，绝不打印含 secret 的完整 URL。"""
+    try:
+        return urlparse(url).hostname or "?"
+    except Exception:
+        return "?"
+
+
+def is_allowed_webhook(url: str) -> bool:
+    """SSRF 防护：仅允许 https 的飞书域名。其余一律拒绝。"""
+    if not url:
+        return False
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme != "https":
+        return False
+    return p.hostname in FEISHU_ALLOWED_HOSTS

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -70,3 +70,22 @@ def build_feishu_card(kind: str, task_name: str, profile: str,
             ],
         },
     }
+
+
+async def send_webhook(url: str, payload: dict, timeout: float = 10.0) -> bool:
+    """best-effort 发送 webhook。先 SSRF 校验；失败只 log（不含完整 URL）、返回 False、不抛。"""
+    if not is_allowed_webhook(url):
+        log.warning("拒绝非法 webhook 目标 host=%s", _safe_host(url))
+        return False
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, json=payload, timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as resp:
+                if resp.status // 100 == 2:
+                    return True
+                log.warning("webhook 推送失败 host=%s status=%s", _safe_host(url), resp.status)
+                return False
+    except Exception as e:
+        log.warning("webhook 推送异常 host=%s err=%s", _safe_host(url), type(e).__name__)
+        return False

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -43,3 +43,30 @@ def is_allowed_webhook(url: str) -> bool:
     if p.scheme != "https":
         return False
     return p.hostname in FEISHU_ALLOWED_HOSTS
+
+
+def build_feishu_card(kind: str, task_name: str, profile: str,
+                      rate: float, threshold: int, ts: str) -> dict:
+    """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。"""
+    if kind == "recover":
+        template, title, color = "green", "✅ 已恢复", "green"
+    else:
+        template, title, color = "red", "🔴 拨测告警", "red"
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "config": {"wide_screen_mode": True},
+            "header": {"template": template,
+                       "title": {"tag": "plain_text", "content": title}},
+            "elements": [
+                {"tag": "div", "fields": [
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**任务**\n{task_name}"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**阈值**\n{threshold}%"}},
+                ]},
+                {"tag": "hr"},
+                {"tag": "note", "elements": [{"tag": "lark_md", "content": f"⏰ {ts} · AITokenPerf"}]},
+            ],
+        },
+    }

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -226,7 +226,8 @@ class TaskScheduler:
 
 async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
-    from app.db import get_run_success_rate, update_scheduled_task
+    from app.db import get_run_success_rate
+    # notifier 在函数内 import：保持 send_webhook 在调用时解析，便于测试 monkeypatch
     from app.notifier import evaluate_alert, build_feishu_card, send_webhook
 
     if not task_row.get("alert_enabled") or not (task_row.get("alert_webhook") or "").strip():
@@ -240,9 +241,9 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     prev = task_row.get("alert_state") or "ok"
     new_state, action = evaluate_alert(prev, rate, threshold)
     if action:
-        profile = ", ".join(task_row.get("profile_ids", []) or []) or "-"
+        profiles_text = ", ".join(task_row.get("profile_ids", []) or []) or "-"
         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        card = build_feishu_card(action, task_row.get("name", ""), profile, rate, threshold, ts)
+        card = build_feishu_card(action, task_row.get("name", ""), profiles_text, rate, threshold, ts)
         await send_webhook(task_row["alert_webhook"], card)
     if new_state != prev:
         await update_scheduled_task(task_id, alert_state=new_state)

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -224,6 +224,30 @@ class TaskScheduler:
 
 # ── 模块级工具函数 ───────────────────────────────────────
 
+async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
+    """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
+    from app.db import get_run_success_rate, update_scheduled_task
+    from app.notifier import evaluate_alert, build_feishu_card, send_webhook
+
+    if not task_row.get("alert_enabled") or not (task_row.get("alert_webhook") or "").strip():
+        return
+    success, total = await get_run_success_rate(run_ids)
+    if total == 0:
+        log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
+        return
+    rate = success / total * 100
+    threshold = int(task_row.get("alert_threshold") or 90)
+    prev = task_row.get("alert_state") or "ok"
+    new_state, action = evaluate_alert(prev, rate, threshold)
+    if action:
+        profile = ", ".join(task_row.get("profile_ids", []) or []) or "-"
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        card = build_feishu_card(action, task_row.get("name", ""), profile, rate, threshold, ts)
+        await send_webhook(task_row["alert_webhook"], card)
+    if new_state != prev:
+        await update_scheduled_task(task_id, alert_state=new_state)
+
+
 async def _run_scheduled_task(task_id: int):
     """执行一个定时任务：为每个 profile 并行跑 benchmark"""
     from app.config import RUN_MAX_GLOBAL_SLOTS, RUN_MAX_USER_SLOTS
@@ -307,6 +331,7 @@ async def _run_scheduled_task(task_id: int):
         return
 
     bench_tasks = []
+    run_ids = []
 
     for profile, body in run_plans:
         try:
@@ -327,6 +352,7 @@ async def _run_scheduled_task(task_id: int):
         if result.get("error"):
             log_error("scheduler:run_create_failed", error=result["error"], task_id=task_id)
             continue
+        run_ids.append(result["run_id"])
         bench_tasks.extend(manager.get_run_tasks(result["run_id"]))
 
     if not bench_tasks:
@@ -351,3 +377,10 @@ async def _run_scheduled_task(task_id: int):
 
     log.info("定时任务 #%d 本次保存 %d 条结果", task_id, total_saved)
     log_bench("scheduler:complete", task_id=task_id, results_saved=total_saved)
+
+    # 失败告警评估（best-effort，绝不影响主流程）
+    try:
+        await _maybe_send_alert(task_id, task_row, run_ids)
+    except Exception as e:
+        log.error("定时任务 #%d 告警评估失败: %s", task_id, e)
+        log_error("scheduler:alert_error", error=str(e), task_id=task_id)

--- a/app/server.py
+++ b/app/server.py
@@ -2025,6 +2025,28 @@ async def list_schedules(user: dict = Depends(get_current_user)):
     return {"schedules": tasks}
 
 
+def _extract_alert_fields(body: dict):
+    """从请求体提取并校验告警字段。返回 (fields, error)。error 非空表示校验失败。"""
+    from app.notifier import is_allowed_webhook
+    out = {}
+    if "alert_enabled" in body:
+        out["alert_enabled"] = bool(body["alert_enabled"])
+    if "alert_threshold" in body:
+        try:
+            t = int(body["alert_threshold"])
+        except (ValueError, TypeError):
+            return None, "alert_threshold 必须是 0-100 的整数"
+        if not (0 <= t <= 100):
+            return None, "alert_threshold 必须在 0-100 之间"
+        out["alert_threshold"] = t
+    if "alert_webhook" in body:
+        wh = (body.get("alert_webhook") or "").strip()
+        if wh and not is_allowed_webhook(wh):
+            return None, "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"
+        out["alert_webhook"] = wh
+    return out, None
+
+
 @app.post("/api/schedules")
 async def create_schedule(request: Request, user: dict = Depends(get_current_user)):
     from app.db import create_scheduled_task, get_scheduled_task, count_user_scheduled_tasks
@@ -2060,8 +2082,15 @@ async def create_schedule(request: Request, user: dict = Depends(get_current_use
     if sv_int < 60:
         return JSONResponse({"error": "定时任务间隔不能小于 60 秒"}, status_code=400)
 
+    alert_fields, alert_err = _extract_alert_fields(body)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+
     sid = await create_scheduled_task(
         user_id, name, profile_ids, configs_json, schedule_type, schedule_value,
+        alert_webhook=alert_fields.get("alert_webhook", ""),
+        alert_threshold=alert_fields.get("alert_threshold", 90),
+        alert_enabled=alert_fields.get("alert_enabled", False),
     )
     if _scheduler:
         _scheduler.start_loop(sid)
@@ -2091,6 +2120,11 @@ async def update_schedule(task_id: int, request: Request, user: dict = Depends(g
             return JSONResponse({"error": "schedule_value 必须是正整数"}, status_code=400)
         if sv_int < 60:
             return JSONResponse({"error": "定时任务间隔不能小于 60 秒"}, status_code=400)
+
+    alert_fields, alert_err = _extract_alert_fields(body)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+    fields.update(alert_fields)
 
     if fields:
         await update_scheduled_task(task_id, **fields)

--- a/app/server.py
+++ b/app/server.py
@@ -2202,6 +2202,25 @@ async def run_schedule_now(task_id: int, user: dict = Depends(get_current_user))
     return {"status": "triggered"}
 
 
+@app.post("/api/schedules/{task_id}/alert-test")
+async def alert_test(task_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_scheduled_task
+    from app.notifier import build_feishu_card, send_webhook, is_allowed_webhook
+    from datetime import datetime
+    task_row = await get_scheduled_task(task_id)
+    if not task_row or task_row["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    webhook = (task_row.get("alert_webhook") or "").strip()
+    if not webhook or not is_allowed_webhook(webhook):
+        return JSONResponse({"error": "请先配置合法的飞书 webhook"}, status_code=400)
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    card = build_feishu_card("alert", task_row.get("name", ""), "测试",
+                             0.0, int(task_row.get("alert_threshold") or 90), ts)
+    card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
+    ok = await send_webhook(webhook, card)
+    return {"ok": ok}
+
+
 @app.get("/api/schedules/{task_id}/results")
 async def get_schedule_results(task_id: int, limit: int = 100, offset: int = 0, hours: int | None = None,
                                user: dict = Depends(get_current_user)):

--- a/app/server.py
+++ b/app/server.py
@@ -2205,6 +2205,7 @@ async def run_schedule_now(task_id: int, user: dict = Depends(get_current_user))
 @app.post("/api/schedules/{task_id}/alert-test")
 async def alert_test(task_id: int, user: dict = Depends(get_current_user)):
     from app.db import get_scheduled_task
+    # notifier 函数内 import：保持 send_webhook 调用时解析，便于测试 monkeypatch，勿上移顶部
     from app.notifier import build_feishu_card, send_webhook, is_allowed_webhook
     from datetime import datetime
     task_row = await get_scheduled_task(task_id)

--- a/docs/superpowers/plans/2026-06-04-scheduled-task-alerting.md
+++ b/docs/superpowers/plans/2026-06-04-scheduled-task-alerting.md
@@ -1,0 +1,1055 @@
+# 定时拨测失败告警闭环 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 定时拨测成功率低于阈值时，主动推送飞书卡片告警（含恢复通知），无需用户开着页面。
+
+**Architecture:** 每个定时任务配 webhook+阈值（存 `scheduled_tasks` 新列）。`scheduler._run_scheduled_task` 跑完后，从落库结果聚合成功率，纯函数 `evaluate_alert` 判定状态翻转，仅翻转时发卡片并写回 `alert_state`。告警逻辑集中在新模块 `app/notifier.py`，best-effort、SSRF 限飞书域名、不影响拨测主流程。
+
+**Tech Stack:** Python / FastAPI / SQLAlchemy(SQLite+Postgres 双模) / aiohttp / pytest / Vue 3。
+
+**关联 spec:** `docs/superpowers/specs/2026-06-04-scheduled-task-alerting-design.md`（issue #30）
+
+---
+
+## 文件结构
+
+| 文件 | 职责 |
+|---|---|
+| `app/notifier.py`（新建） | 告警纯逻辑：`evaluate_alert` 状态机、`is_allowed_webhook` SSRF 校验、`build_feishu_card` 卡片构造、`send_webhook` 发送 |
+| `app/db.py`（改） | `scheduled_tasks` 加 4 列（两处 DDL + 迁移）、`create_scheduled_task` 扩参、`update_scheduled_task` 白名单加列、新增 `get_run_success_rate` |
+| `app/scheduler.py`（改） | `_maybe_send_alert` + 在 `_run_scheduled_task` 末尾接入（捕获 run_ids、try/except） |
+| `app/server.py`（改） | create/update schedule 接收+校验告警字段、新增 `POST /api/schedules/{id}/alert-test` |
+| `frontend/src/views/TasksView.vue`（改） | 任务表单告警配置区 + 测试按钮 |
+| `frontend/src/components/SiteSchedulesTab.vue`（改） | 同上（另一入口） |
+| `tests/test_notifier.py`、`tests/test_alert_db.py`、`tests/test_alert_scheduler.py`、`tests/test_alert_api.py`（新建） | 单测 |
+
+约定：后端 TDD（pytest），每个 Task 末尾提交。前端 implement + `bun run build` 校验。
+
+---
+
+### Task 1: notifier — evaluate_alert 状态机
+
+**Files:**
+- Create: `app/notifier.py`
+- Test: `tests/test_notifier.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+# tests/test_notifier.py
+from app.notifier import evaluate_alert
+
+
+def test_alert_fires_on_ok_to_abnormal():
+    assert evaluate_alert("ok", 72.0, 90) == ("alerting", "alert")
+
+
+def test_no_repeat_while_abnormal():
+    assert evaluate_alert("alerting", 50.0, 90) == ("alerting", None)
+
+
+def test_recover_on_abnormal_to_ok():
+    assert evaluate_alert("alerting", 95.0, 90) == ("ok", "recover")
+
+
+def test_no_action_while_ok():
+    assert evaluate_alert("ok", 99.0, 90) == ("ok", None)
+
+
+def test_threshold_boundary_is_normal():
+    # rate == threshold 用 < 判定 → 视为正常
+    assert evaluate_alert("ok", 90.0, 90) == ("ok", None)
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_notifier.py -q`
+Expected: FAIL（`ModuleNotFoundError: app.notifier`）
+
+- [ ] **Step 3: 实现**
+
+```python
+# app/notifier.py
+#!/usr/bin/env python3
+"""告警通知模块：状态机判定 + 飞书卡片 + webhook 发送（SSRF 限飞书域名）。"""
+
+import logging
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+import aiohttp
+
+log = logging.getLogger("notifier")
+
+ALERT_OK = "ok"
+ALERT_ALERTING = "alerting"
+FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
+
+
+def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> Tuple[str, Optional[str]]:
+    """返回 (新状态, 动作)。动作 ∈ {None, 'alert', 'recover'}。仅状态翻转时给动作。"""
+    abnormal = success_rate < threshold
+    if abnormal and prev_state != ALERT_ALERTING:
+        return ALERT_ALERTING, "alert"
+    if not abnormal and prev_state == ALERT_ALERTING:
+        return ALERT_OK, "recover"
+    return prev_state, None
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_notifier.py -q`
+Expected: PASS（5 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/notifier.py tests/test_notifier.py
+git commit -m "feat(notifier): 告警状态机 evaluate_alert (#30)"
+```
+
+---
+
+### Task 2: notifier — is_allowed_webhook（SSRF 校验）
+
+**Files:**
+- Modify: `app/notifier.py`
+- Test: `tests/test_notifier.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+```python
+# tests/test_notifier.py 追加
+from app.notifier import is_allowed_webhook
+
+
+def test_feishu_https_allowed():
+    assert is_allowed_webhook("https://open.feishu.cn/open-apis/bot/v2/hook/xxx") is True
+
+
+def test_larksuite_allowed():
+    assert is_allowed_webhook("https://open.larksuite.com/open-apis/bot/v2/hook/xxx") is True
+
+
+def test_http_rejected():
+    assert is_allowed_webhook("http://open.feishu.cn/x") is False
+
+
+def test_localhost_rejected():
+    assert is_allowed_webhook("https://localhost/x") is False
+
+
+def test_internal_ip_rejected():
+    assert is_allowed_webhook("https://169.254.169.254/latest/meta-data") is False
+
+
+def test_other_domain_rejected():
+    assert is_allowed_webhook("https://evil.com/x") is False
+
+
+def test_empty_rejected():
+    assert is_allowed_webhook("") is False
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_notifier.py -k is_allowed -q` → 实际是 import 失败/未定义。
+Expected: FAIL（`cannot import name 'is_allowed_webhook'`）
+
+- [ ] **Step 3: 实现（追加到 app/notifier.py）**
+
+```python
+def _safe_host(url: str) -> str:
+    """日志脱敏：只取 host，绝不打印含 secret 的完整 URL。"""
+    try:
+        return urlparse(url).hostname or "?"
+    except Exception:
+        return "?"
+
+
+def is_allowed_webhook(url: str) -> bool:
+    """SSRF 防护：仅允许 https 的飞书域名。其余（http/内网/localhost/任意域名）一律拒绝。"""
+    if not url:
+        return False
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme != "https":
+        return False
+    return p.hostname in FEISHU_ALLOWED_HOSTS
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_notifier.py -q`
+Expected: PASS（12 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/notifier.py tests/test_notifier.py
+git commit -m "feat(notifier): SSRF 限飞书域名 is_allowed_webhook (#30)"
+```
+
+---
+
+### Task 3: notifier — build_feishu_card
+
+**Files:**
+- Modify: `app/notifier.py`
+- Test: `tests/test_notifier.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+```python
+# tests/test_notifier.py 追加
+from app.notifier import build_feishu_card
+
+
+def test_alert_card_red_header():
+    card = build_feishu_card("alert", "主力渠道", "OpenAI-A", 72.0, 90, "2026-06-04 10:30")
+    assert card["msg_type"] == "interactive"
+    assert card["card"]["config"]["wide_screen_mode"] is True
+    assert card["card"]["header"]["template"] == "red"
+    assert "告警" in card["card"]["header"]["title"]["content"]
+    flat = str(card)
+    assert "72.0%" in flat and "90%" in flat and "主力渠道" in flat
+
+
+def test_recover_card_green_header():
+    card = build_feishu_card("recover", "主力渠道", "OpenAI-A", 95.0, 90, "2026-06-04 10:30")
+    assert card["card"]["header"]["template"] == "green"
+    assert "恢复" in card["card"]["header"]["title"]["content"]
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_notifier.py -k card -q`
+Expected: FAIL（`cannot import name 'build_feishu_card'`）
+
+- [ ] **Step 3: 实现（追加到 app/notifier.py）**
+
+```python
+def build_feishu_card(kind: str, task_name: str, profile: str,
+                      rate: float, threshold: int, ts: str) -> dict:
+    """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。"""
+    if kind == "recover":
+        template, title, color = "green", "✅ 已恢复", "green"
+    else:
+        template, title, color = "red", "🔴 拨测告警", "red"
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "config": {"wide_screen_mode": True},
+            "header": {"template": template,
+                       "title": {"tag": "plain_text", "content": title}},
+            "elements": [
+                {"tag": "div", "fields": [
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**任务**\n{task_name}"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
+                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**阈值**\n{threshold}%"}},
+                ]},
+                {"tag": "hr"},
+                {"tag": "note", "elements": [{"tag": "lark_md", "content": f"⏰ {ts} · AITokenPerf"}]},
+            ],
+        },
+    }
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_notifier.py -q`
+Expected: PASS（14 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/notifier.py tests/test_notifier.py
+git commit -m "feat(notifier): 飞书告警卡片 build_feishu_card (#30)"
+```
+
+---
+
+### Task 4: notifier — send_webhook（异步，SSRF 守卫，日志脱敏）
+
+**Files:**
+- Modify: `app/notifier.py`
+- Test: `tests/test_notifier.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+```python
+# tests/test_notifier.py 追加
+import pytest
+from app import notifier
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_rejects_ssrf():
+    # 非飞书域名直接拒绝，不发网络请求
+    assert await notifier.send_webhook("https://evil.com/x", {"a": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_success(monkeypatch):
+    class FakeResp:
+        status = 200
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+    class FakeSession:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def post(self, *a, **k): return FakeResp()
+
+    monkeypatch.setattr(notifier.aiohttp, "ClientSession", FakeSession)
+    ok = await notifier.send_webhook("https://open.feishu.cn/open-apis/bot/v2/hook/x", {"a": 1})
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_non_2xx_returns_false(monkeypatch):
+    class FakeResp:
+        status = 500
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+    class FakeSession:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def post(self, *a, **k): return FakeResp()
+
+    monkeypatch.setattr(notifier.aiohttp, "ClientSession", FakeSession)
+    assert await notifier.send_webhook("https://open.feishu.cn/x", {"a": 1}) is False
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_notifier.py -k send_webhook -q`
+Expected: FAIL（`module 'app.notifier' has no attribute 'send_webhook'`）
+
+- [ ] **Step 3: 实现（追加到 app/notifier.py）**
+
+```python
+async def send_webhook(url: str, payload: dict, timeout: float = 10.0) -> bool:
+    """best-effort 发送 webhook。先 SSRF 校验；失败只 log（不含完整 URL）、返回 False、不抛。"""
+    if not is_allowed_webhook(url):
+        log.warning("拒绝非法 webhook 目标 host=%s", _safe_host(url))
+        return False
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, json=payload, timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as resp:
+                if resp.status // 100 == 2:
+                    return True
+                log.warning("webhook 推送失败 host=%s status=%s", _safe_host(url), resp.status)
+                return False
+    except Exception as e:
+        log.warning("webhook 推送异常 host=%s err=%s", _safe_host(url), type(e).__name__)
+        return False
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_notifier.py -q`
+Expected: PASS（17 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/notifier.py tests/test_notifier.py
+git commit -m "feat(notifier): best-effort send_webhook + 日志脱敏 (#30)"
+```
+
+---
+
+### Task 5: DB — scheduled_tasks 加 4 列（DDL + 迁移 + CRUD 白名单）
+
+**Files:**
+- Modify: `app/db.py`（两处 `CREATE TABLE scheduled_tasks`、迁移块、`create_scheduled_task`、`update_scheduled_task`）
+- Test: `tests/test_alert_db.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+# tests/test_alert_db.py
+import pytest
+from app.db import create_scheduled_task, get_scheduled_task, update_scheduled_task
+
+
+@pytest.mark.asyncio
+async def test_alert_fields_roundtrip():
+    sid = await create_scheduled_task(
+        1, "t", [], {}, "interval", "300",
+        alert_webhook="https://open.feishu.cn/x", alert_threshold=80, alert_enabled=True,
+    )
+    row = await get_scheduled_task(sid)
+    assert row["alert_webhook"] == "https://open.feishu.cn/x"
+    assert row["alert_threshold"] == 80
+    assert bool(row["alert_enabled"]) is True
+    assert row["alert_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_update_alert_state_persists():
+    sid = await create_scheduled_task(1, "t2", [], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_state="alerting")
+    row = await get_scheduled_task(sid)
+    assert row["alert_state"] == "alerting"
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_alert_db.py -q`
+Expected: FAIL（`create_scheduled_task() got an unexpected keyword argument 'alert_webhook'`）
+
+- [ ] **Step 3a: 两处建表 DDL 加列**
+
+`app/db.py` 的 `_SQLITE_SCHEMA` 中 `scheduled_tasks` 表，在 `run_count ...` 行后、`created_at` 前加：
+
+```sql
+    alert_webhook   TEXT NOT NULL DEFAULT '',
+    alert_threshold INTEGER NOT NULL DEFAULT 90,
+    alert_enabled   INTEGER NOT NULL DEFAULT 0,
+    alert_state     TEXT NOT NULL DEFAULT 'ok',
+```
+
+`_PG_SCHEMA` 的 `scheduled_tasks` 表同位置加：
+
+```sql
+    alert_webhook   TEXT NOT NULL DEFAULT '',
+    alert_threshold INTEGER NOT NULL DEFAULT 90,
+    alert_enabled   BOOLEAN NOT NULL DEFAULT FALSE,
+    alert_state     TEXT NOT NULL DEFAULT 'ok',
+```
+
+- [ ] **Step 3b: 迁移（存量表加列）**
+
+在 `init_db` 内、现有 results 列迁移之后，加 scheduled_tasks 列迁移。找到 `if _is_sqlite:` / `else:` 处理 results `ADD COLUMN` 的块，在其后追加：
+
+```python
+        # scheduled_tasks 告警列迁移
+        if _is_sqlite:
+            for col_def in [
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_webhook TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_threshold INTEGER NOT NULL DEFAULT 90",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_enabled INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_state TEXT NOT NULL DEFAULT 'ok'",
+            ]:
+                try:
+                    await conn.execute(text(col_def))
+                except Exception:
+                    pass
+        else:
+            for col_def in [
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_webhook TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_threshold INTEGER NOT NULL DEFAULT 90",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_state TEXT NOT NULL DEFAULT 'ok'",
+            ]:
+                await conn.execute(text(col_def))
+```
+
+- [ ] **Step 3c: 扩展 create_scheduled_task**
+
+替换 `create_scheduled_task` 为：
+
+```python
+async def create_scheduled_task(user_id: int, name: str, profile_ids: list,
+                                 configs_json: dict, schedule_type: str,
+                                 schedule_value: str, alert_webhook: str = "",
+                                 alert_threshold: int = 90,
+                                 alert_enabled: bool = False) -> int:
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("""INSERT INTO scheduled_tasks (user_id, name, profile_ids, configs_json,
+                    schedule_type, schedule_value, alert_webhook, alert_threshold, alert_enabled)
+                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :aw, :at, :ae)"""),
+            {"uid": user_id, "name": name, "pids": json.dumps(profile_ids),
+             "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value,
+             "aw": alert_webhook, "at": alert_threshold,
+             "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled)},
+        )
+        if _is_sqlite:
+            return cur.lastrowid
+        result = await conn.execute(text("SELECT lastval()"))
+        return (result.fetchone())[0]
+```
+
+- [ ] **Step 3d: update_scheduled_task 白名单加 4 列**
+
+`update_scheduled_task` 的 `allowed` 集合改为：
+
+```python
+        allowed = {"name", "profile_ids", "configs_json", "schedule_type",
+                   "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
+                   "alert_webhook", "alert_threshold", "alert_enabled", "alert_state"}
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_alert_db.py -q`
+Expected: PASS（2 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat(db): scheduled_tasks 告警列 + CRUD 白名单 (#30)"
+```
+
+---
+
+### Task 6: DB — get_run_success_rate 聚合助手
+
+**Files:**
+- Modify: `app/db.py`（新增函数）
+- Test: `tests/test_alert_db.py`
+
+> 说明：bench task 的 `success_count/total_count` 每换并发档会被清零（`server.py:373-376`），不可信。改为聚合本轮落库结果的 `summary_json`。
+
+- [ ] **Step 1: 追加失败测试**
+
+```python
+# tests/test_alert_db.py 追加
+import json
+from app.db import save_result, get_run_success_rate
+
+
+@pytest.mark.asyncio
+async def test_get_run_success_rate_aggregates():
+    for i, (succ, tot) in enumerate([(8, 10), (5, 10)]):
+        await save_result(
+            user_id=1, test_id=f"t{i}", filename=f"f{i}.json", timestamp="20260604_120000",
+            config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-x",
+        )
+    assert await get_run_success_rate(["run-x"]) == (13, 20)
+
+
+@pytest.mark.asyncio
+async def test_get_run_success_rate_empty():
+    assert await get_run_success_rate([]) == (0, 0)
+    assert await get_run_success_rate(["nope"]) == (0, 0)
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_alert_db.py -k success_rate -q`
+Expected: FAIL（`cannot import name 'get_run_success_rate'`）
+
+- [ ] **Step 3: 实现（加到 app/db.py，紧邻其他 results 查询函数）**
+
+```python
+async def get_run_success_rate(run_ids: list) -> tuple:
+    """聚合给定 run 的全部 result 行的 (success_count, total_requests)。返回 (success, total)。"""
+    if not run_ids:
+        return (0, 0)
+    placeholders = ",".join(f":r{i}" for i in range(len(run_ids)))
+    params = {f"r{i}": rid for i, rid in enumerate(run_ids)}
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text(f"SELECT summary_json FROM results WHERE run_id IN ({placeholders})"),
+            params,
+        )
+        rows = cur.fetchall()
+    success = total = 0
+    for row in rows:
+        try:
+            s = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        success += int(s.get("success_count") or 0)
+        total += int(s.get("total_requests") or 0)
+    return (success, total)
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_alert_db.py -q`
+Expected: PASS（4 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat(db): get_run_success_rate 聚合落库结果 (#30)"
+```
+
+---
+
+### Task 7: scheduler — _maybe_send_alert 接入
+
+**Files:**
+- Modify: `app/scheduler.py`（新增模块函数 + `_run_scheduled_task` 末尾接入）
+- Test: `tests/test_alert_scheduler.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+# tests/test_alert_scheduler.py
+import json
+import pytest
+from app import notifier, scheduler
+from app.db import create_scheduled_task, save_result, get_scheduled_task
+
+
+async def _seed(rate_pair, alert_state="ok", enabled=True):
+    succ, tot = rate_pair
+    sid = await create_scheduled_task(
+        1, "t", ["SiteA"], {}, "interval", "300",
+        alert_webhook="https://open.feishu.cn/x", alert_threshold=90, alert_enabled=enabled,
+    )
+    if alert_state != "ok":
+        from app.db import update_scheduled_task
+        await update_scheduled_task(sid, alert_state=alert_state)
+    await save_result(
+        user_id=1, test_id="a", filename="a.json", timestamp="20260604_120000",
+        config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+        percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_alert_fires_and_writes_state(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((5, 10))  # 50% < 90%
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+
+    assert len(sent) == 1
+    assert (await get_scheduled_task(sid))["alert_state"] == "alerting"
+
+
+@pytest.mark.asyncio
+async def test_no_alert_when_disabled(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((5, 10), enabled=False)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_recover_when_back_to_normal(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((10, 10), alert_state="alerting")  # 100% >= 90%, 之前在告警
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 1
+    assert (await get_scheduled_task(sid))["alert_state"] == "ok"
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_alert_scheduler.py -q`
+Expected: FAIL（`module 'app.scheduler' has no attribute '_maybe_send_alert'`）
+
+- [ ] **Step 3a: 新增 _maybe_send_alert（加到 app/scheduler.py 模块级，`_run_scheduled_task` 之前或之后均可）**
+
+```python
+async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
+    """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
+    from app.db import get_run_success_rate, update_scheduled_task
+    from app.notifier import evaluate_alert, build_feishu_card, send_webhook
+
+    if not task_row.get("alert_enabled") or not (task_row.get("alert_webhook") or "").strip():
+        return
+    success, total = await get_run_success_rate(run_ids)
+    if total == 0:
+        log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
+        return
+    rate = success / total * 100
+    threshold = int(task_row.get("alert_threshold") or 90)
+    prev = task_row.get("alert_state") or "ok"
+    new_state, action = evaluate_alert(prev, rate, threshold)
+    if action:
+        profile = ", ".join(task_row.get("profile_ids", []) or []) or "-"
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        card = build_feishu_card(action, task_row.get("name", ""), profile, rate, threshold, ts)
+        await send_webhook(task_row["alert_webhook"], card)
+    if new_state != prev:
+        await update_scheduled_task(task_id, alert_state=new_state)
+```
+
+- [ ] **Step 3b: 在 _run_scheduled_task 捕获 run_ids 并接入**
+
+在 `_run_scheduled_task` 中，`bench_tasks = []` 之后加 `run_ids = []`。在 `bench_tasks.extend(manager.get_run_tasks(result["run_id"]))` 之前加 `run_ids.append(result["run_id"])`。
+
+在函数末尾 `log_bench("scheduler:complete", ...)` 之后追加：
+
+```python
+    # 失败告警评估（best-effort，绝不影响主流程）
+    try:
+        await _maybe_send_alert(task_id, task_row, run_ids)
+    except Exception as e:
+        log.error("定时任务 #%d 告警评估失败: %s", task_id, e)
+        log_error("scheduler:alert_error", error=str(e), task_id=task_id)
+```
+
+（`task_row` 在 `_run_scheduled_task` 开头已 `get_scheduled_task` 取到，含新列；`datetime` 已在文件顶部导入。）
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_alert_scheduler.py -q`
+Expected: PASS（3 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/scheduler.py tests/test_alert_scheduler.py
+git commit -m "feat(scheduler): 接入失败告警评估 _maybe_send_alert (#30)"
+```
+
+---
+
+### Task 8: server — create/update schedule 接收+校验告警字段
+
+**Files:**
+- Modify: `app/server.py`（新增 `_extract_alert_fields` 助手 + `create_schedule` + `update_schedule`）
+- Test: `tests/test_alert_api.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+# tests/test_alert_api.py
+import pytest
+from tests.conftest import auth_headers
+from app.db import get_scheduled_task
+
+
+async def _make_profile(client, headers):
+    await client.post("/api/profiles/save", json={
+        "name": "s", "base_url": "https://api.example.com", "api_key": "sk-x",
+        "api_key_action": "replace", "models": ["gpt-4o-mini"], "provider": "openai",
+    }, headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_with_alert(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_threshold": 85,
+        "alert_webhook": "https://open.feishu.cn/x",
+    }, headers=headers)
+    assert resp.status_code == 200
+    sid = resp.json()["id"]
+    row = await get_scheduled_task(sid)
+    assert row["alert_threshold"] == 85
+    assert row["alert_webhook"] == "https://open.feishu.cn/x"
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_bad_webhook(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_webhook": "https://evil.com/x",
+    }, headers=headers)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_bad_threshold(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_threshold": 250,
+    }, headers=headers)
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_alert_api.py -q`
+Expected: FAIL（创建带 alert 字段未持久化 / 非法值未被拒 → 断言失败）
+
+- [ ] **Step 3a: 新增 _extract_alert_fields（加到 app/server.py 模块级，靠近其他 schedule 辅助函数）**
+
+```python
+def _extract_alert_fields(body: dict):
+    """从请求体提取并校验告警字段。返回 (fields, error)。error 非空表示校验失败。"""
+    from app.notifier import is_allowed_webhook
+    out = {}
+    if "alert_enabled" in body:
+        out["alert_enabled"] = bool(body["alert_enabled"])
+    if "alert_threshold" in body:
+        try:
+            t = int(body["alert_threshold"])
+        except (ValueError, TypeError):
+            return None, "alert_threshold 必须是 0-100 的整数"
+        if not (0 <= t <= 100):
+            return None, "alert_threshold 必须在 0-100 之间"
+        out["alert_threshold"] = t
+    if "alert_webhook" in body:
+        wh = (body.get("alert_webhook") or "").strip()
+        if wh and not is_allowed_webhook(wh):
+            return None, "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"
+        out["alert_webhook"] = wh
+    return out, None
+```
+
+- [ ] **Step 3b: create_schedule 接入**
+
+在 `create_schedule` 内，`schedule_value` 校验之后、`create_scheduled_task(...)` 调用之前加：
+
+```python
+    alert_fields, alert_err = _extract_alert_fields(body)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+```
+
+并把建任务调用改为：
+
+```python
+    sid = await create_scheduled_task(
+        user_id, name, profile_ids, configs_json, schedule_type, schedule_value,
+        alert_webhook=alert_fields.get("alert_webhook", ""),
+        alert_threshold=alert_fields.get("alert_threshold", 90),
+        alert_enabled=alert_fields.get("alert_enabled", False),
+    )
+```
+
+- [ ] **Step 3c: update_schedule 接入**
+
+在 `update_schedule` 内，构造 `fields` 之后加：
+
+```python
+    alert_fields, alert_err = _extract_alert_fields(body)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+    fields.update(alert_fields)
+```
+
+（`update_scheduled_task` 白名单已在 Task 5 包含这些列。）
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_alert_api.py -q`
+Expected: PASS（3 passed）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/server.py tests/test_alert_api.py
+git commit -m "feat(server): 定时任务 CRUD 接收+校验告警字段 (#30)"
+```
+
+---
+
+### Task 9: server — POST /api/schedules/{id}/alert-test
+
+**Files:**
+- Modify: `app/server.py`（新增端点）
+- Test: `tests/test_alert_api.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+```python
+# tests/test_alert_api.py 追加
+from app import notifier
+
+
+@pytest.mark.asyncio
+async def test_alert_test_endpoint(client, monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(url); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_enabled": True,
+        "alert_webhook": "https://open.feishu.cn/x",
+    }, headers=headers)
+    sid = resp.json()["id"]
+
+    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_alert_test_requires_webhook(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={"name": "t", "profile_ids": ["s"]}, headers=headers)
+    sid = resp.json()["id"]
+    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
+    assert r.status_code == 400
+```
+
+- [ ] **Step 2: 运行验证失败**
+
+Run: `python -m pytest tests/test_alert_api.py -k alert_test -q`
+Expected: FAIL（404/405，端点不存在）
+
+- [ ] **Step 3: 实现（加到 app/server.py，靠近其他 schedules 路由）**
+
+```python
+@app.post("/api/schedules/{task_id}/alert-test")
+async def alert_test(task_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_scheduled_task
+    from app.notifier import build_feishu_card, send_webhook, is_allowed_webhook
+    from datetime import datetime
+    task_row = await get_scheduled_task(task_id)
+    if not task_row or task_row["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    webhook = (task_row.get("alert_webhook") or "").strip()
+    if not webhook or not is_allowed_webhook(webhook):
+        return JSONResponse({"error": "请先配置合法的飞书 webhook"}, status_code=400)
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    card = build_feishu_card("alert", task_row.get("name", ""), "测试",
+                             0.0, int(task_row.get("alert_threshold") or 90), ts)
+    card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
+    ok = await send_webhook(webhook, card)
+    return {"ok": ok}
+```
+
+- [ ] **Step 4: 运行验证通过**
+
+Run: `python -m pytest tests/test_alert_api.py -q`
+Expected: PASS（5 passed）
+
+- [ ] **Step 5: 运行全量后端回归**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS（全绿）
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add app/server.py tests/test_alert_api.py
+git commit -m "feat(server): 告警测试端点 /api/schedules/{id}/alert-test (#30)"
+```
+
+---
+
+### Task 10: 前端 — TasksView 告警配置区
+
+**Files:**
+- Modify: `frontend/src/views/TasksView.vue`
+- Modify: `frontend/src/api/index.js`（加 alertTest 调用）
+
+> 说明：照搬现有任务表单（约 TasksView.vue:289/297）的字段绑定与样式风格，加一段「告警」配置。不引入新组件，复用现有 input/switch 样式。
+
+- [ ] **Step 1: api 层加调用**
+
+在 `frontend/src/api/index.js` 加：
+
+```javascript
+export const alertTestApi = (id) => api(`/api/schedules/${id}/alert-test`, { method: 'POST' })
+```
+
+- [ ] **Step 2: 表单 state 加字段**
+
+在创建/编辑任务的响应式表单对象里加：`alert_enabled: false, alert_webhook: '', alert_threshold: 90`。编辑时从任务行回填这三个字段。
+
+- [ ] **Step 3: 模板加告警区**
+
+在任务表单合适位置（高级参数附近）加：
+
+```html
+<div class="form-section">
+  <label class="form-switch">
+    <input type="checkbox" v-model="form.alert_enabled" />
+    <span>启用失败告警（飞书）</span>
+  </label>
+  <template v-if="form.alert_enabled">
+    <label>飞书 Webhook URL</label>
+    <input v-model.trim="form.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/..." />
+    <label>成功率阈值（%）</label>
+    <input type="number" v-model.number="form.alert_threshold" min="0" max="100" />
+    <button type="button" class="btn-secondary" :disabled="!editingId || !form.alert_webhook" @click="onTestAlert">发送测试消息</button>
+  </template>
+</div>
+```
+
+- [ ] **Step 4: 提交 payload 带上三字段 + 测试按钮处理**
+
+保存任务的 `create`/`update` 请求体里带上 `alert_enabled / alert_webhook / alert_threshold`。加方法：
+
+```javascript
+async function onTestAlert() {
+  try {
+    const r = await alertTestApi(editingId.value)
+    showToast(r.ok ? '测试消息已发送，请检查飞书' : '发送失败，请检查 URL', r.ok ? 'success' : 'error')
+  } catch (e) {
+    showToast('发送失败：' + (e.message || e), 'error')
+  }
+}
+```
+（`alertTestApi` 从 `@/api` 导入；`showToast`/`editingId` 用页面现有的。测试按钮要求任务已保存——`editingId` 存在时才可点。）
+
+- [ ] **Step 5: 构建校验**
+
+Run: `cd frontend && bun run build`
+Expected: 构建成功无报错。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add frontend/src/views/TasksView.vue frontend/src/api/index.js
+git commit -m "feat(web): 定时任务表单告警配置区 + 测试 (#30)"
+```
+
+---
+
+### Task 11: 前端 — SiteSchedulesTab 告警配置区
+
+**Files:**
+- Modify: `frontend/src/components/SiteSchedulesTab.vue`
+
+> 与 Task 10 同款配置区，加到 SiteSchedulesTab 的创建/编辑表单。复用 Task 10 的 `alertTestApi`。
+
+- [ ] **Step 1: 表单 state 加字段**
+
+创建/编辑表单对象加 `alert_enabled: false, alert_webhook: '', alert_threshold: 90`，编辑时回填。
+
+- [ ] **Step 2: 模板加告警区**（同 Task 10 Step 3 的模板片段，绑定到本组件表单对象）
+
+- [ ] **Step 3: 保存 payload 带上三字段；如有「发送测试」按钮，复用 `alertTestApi(id)`（仅已保存任务可用）**
+
+- [ ] **Step 4: 构建校验**
+
+Run: `cd frontend && bun run build`
+Expected: 构建成功。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add frontend/src/components/SiteSchedulesTab.vue
+git commit -m "feat(web): SiteSchedulesTab 告警配置区 (#30)"
+```
+
+---
+
+## 收尾
+
+- [ ] 全量后端测试 `python -m pytest tests/ -q` 全绿
+- [ ] 前端 `cd frontend && bun run build` 成功
+- [ ] 推送分支 `feat/issue-30-failure-alerting`，`gh pr create`（body 含 `Closes #30`）
+- [ ] 真机验证（部署后）：配一个飞书机器人 webhook，跑一次低成功率拨测确认收到红色告警卡片、恢复收到绿色卡片；确认 `<font color>` 渲染是否正常。
+</content>

--- a/docs/superpowers/specs/2026-06-04-scheduled-task-alerting-design.md
+++ b/docs/superpowers/specs/2026-06-04-scheduled-task-alerting-design.md
@@ -38,6 +38,9 @@
 | 通道 | 通用 Webhook，默认**飞书自定义机器人卡片**格式 |
 | 配置粒度 | **每个定时任务单独配**（webhook URL + 阈值 + 开关） |
 | 触发规则 | 成功率 < 阈值（默认 90%）视为异常；**仅状态翻转时推送**（正常→异常 发告警，异常→恢复 发恢复） |
+| 聚合口径 | **任务级单状态**（已与用户确认：一个定时任务只绑一个渠道）。成功率聚合该任务本轮全部结果。多 profile 任务超出 v1 范围——若存在则按全量聚合（可能掩盖单站故障），文档注明 |
+
+> **设计前提（用户确认）**：定时任务为「一个任务一个渠道」。因此任务级一个 `alert_state` 足够，无需 per-profile 状态。
 
 ---
 
@@ -56,12 +59,21 @@
 
 迁移：SQLite 用 `ALTER TABLE ... ADD COLUMN`（沿用 `db.py` 现有列迁移模式，try/except 忽略已存在）；Postgres 用 `ADD COLUMN IF NOT EXISTS`。双模兼容。
 
+**⚠️ 必须同步改的代码点（review 发现，遗漏任一功能即失效）**：
+- 两处建表 DDL 都要加列：`db.py` 的 `_SQLITE_SCHEMA`（`scheduled_tasks` 约 107-122）与 `_PG_SCHEMA`（约 202）。
+- `create_scheduled_task`（`db.py:1074`）的 INSERT 语句与函数签名要接收 `alert_webhook/alert_threshold/alert_enabled`。
+- **`update_scheduled_task` 的 `allowed` 白名单（`db.py:1145`）必须加入 4 个 alert 列**——否则写回 `alert_state` 被静默丢弃，状态机永远翻不了车（这是会让功能完全失效的隐蔽漏点）。
+- `update_schedule` 路由自己的 `allowed` 白名单（`server.py:2079`）也要加 `alert_webhook/alert_threshold/alert_enabled`。
+- 读侧 `get_scheduled_task(s)` 用 `SELECT *`，新列自动带出，无需改。
+
 ### 2. 触发评估
 
 挂在 `scheduler._run_scheduled_task` 完成处（`scheduler.py:350` 附近，已 `gather` 完所有 bench task）：
 
-1. **算成功率**：从 `manager.get_run_tasks(run_id)` 的 bench task 聚合 `success_rate = sum(success_count) / sum(total_count) * 100`（**百分比**，与 `alert_threshold` 同单位；运行中已维护这些字段，无需重查 DB）。
-   - **边界 `total_count == 0`**（任务因容量不足/无 profile 等没真正发出请求）：无法评估成功率，**跳过告警评估、不改 `alert_state`、记一条 log**。不把"没跑成"误判为成功或失败。
+1. **算成功率**（⚠️ review 修正：不能用 bench task 的 `success_count/total_count`）：
+   - 原因：`server.py:373-376` 每进入一个新并发 level 就把这些计数**清零**，任务跑完后它们只反映**最后一档并发**，不是全程。直接用会算错、发出错误告警。
+   - 正确来源：**聚合本轮落库的 result 行**。`_run_scheduled_task` 已知本轮各 run 的 `run_id`（`_start_run_for_profile` 返回）与 bench task 的 `result_filenames`。新增 DB 助手 `get_run_success_rate(run_ids)`：读这些 run 的 result 行，从 `summary_json` 累加 `success_count` 与 `total_requests`，`success_rate = 总成功 / 总请求 * 100`（**百分比**，与 `alert_threshold` 同单位）。
+   - **边界 `总请求 == 0`**（容量不足/无 profile 等没真正发出请求）：无法评估，**跳过评估、不改 `alert_state`、记一条 log**。不把"没跑成"误判为成功或失败。
 2. **纯函数判定**：
    ```python
    def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> tuple[str, str | None]:
@@ -73,9 +85,11 @@
            return 'ok', 'recover'
        return prev_state, None   # 状态未翻转 → 不推送（防刷屏）
    ```
-3. 按动作发卡片，并把新 `alert_state` 写回 DB。
-4. 整段包在 try/except——**告警失败绝不影响拨测主流程与重调度**。
+3. 按动作发卡片，并用 `update_scheduled_task(task_id, alert_state=新状态)` 写回（依赖上面的白名单修正）。
+4. 整段包在 try/except——**告警失败绝不影响拨测主流程与重调度**。放在 `_run_scheduled_task` 末尾、`_release_and_reschedule` 之前；与重调度操作不同列、各自独立事务，无冲突。
 5. 仅当 `alert_enabled` 且 `alert_webhook` 非空时才评估。
+6. **权衡（明确记录）**：先发卡片、无论成功失败都写回新 `alert_state`。这样网络抖动导致单次推送失败时，状态仍翻转、不会下一轮重发刷屏——代价是**那一次告警漏报**，要等下次状态再翻转才会再发。v1 接受此简化（不引入重试队列）。
+7. **多 worker 安全**：`claim_scheduled_task`（`db.py:1222`）保证同一任务每轮只有一个 worker 执行，故评估也只跑一次，不会重复推送。
 
 ### 3. Webhook 推送（`app/notifier.py`）
 
@@ -85,14 +99,21 @@
   - `kind='alert'`：红色头部 `template:"red"`，标题「🔴 拨测告警」，成功率红色。
   - `kind='recover'`：绿色头部 `template:"green"`，标题「✅ 已恢复」，成功率绿色。
 - `async def send_webhook(url, payload, timeout=10) -> bool`
-  - aiohttp POST JSON，**best-effort**：超时/非 2xx/异常只 `log` 并返回 False，**不重试、不抛**。
+  - **先做 SSRF 校验**（见下），再 aiohttp POST JSON，**best-effort**：超时/非 2xx/异常只 `log` 并返回 False，**不重试、不抛**。
+  - **日志脱敏**：失败 log **不得打印完整 URL**（webhook URL 含 secret token），只记 host 或脱敏后的串。
 
-飞书卡片结构：
+**⚠️ SSRF 防护（review 发现的安全硬伤，必须做）**：
+本服务是公网多租户（app.aitokenperf.com），用户可填任意 `alert_webhook`，后端会主动 POST。若不限制，攻击者可填内网地址（`http://169.254.169.254/...` 云元数据、`http://localhost:...` 内部服务）让服务端代为请求。v1 防护：
+- **只允许飞书域名**：`open.feishu.cn` / `open.larksuite.com`，且必须 `https://`。其余一律拒绝（配置保存时校验 + 发送前再校验，双重）。
+- 这同时收窄了 SSRF 面、又契合 v1「只做飞书」的范围。换平台时再扩白名单。
+
+飞书卡片结构（含 `config.wide_screen_mode`，官方示例标配）：
 
 ```json
 {
   "msg_type": "interactive",
   "card": {
+    "config": { "wide_screen_mode": true },
     "header": { "template": "red", "title": {"tag":"plain_text","content":"🔴 拨测告警"} },
     "elements": [
       { "tag": "div", "fields": [
@@ -108,15 +129,18 @@
 }
 ```
 
+> 颜色提示：`<font color='red'>` 在飞书 `lark_md` 不同客户端版本渲染不一致，可能原样显示标签。状态已由红/绿头部表达，成功率文字可保留 `<font>` 但**实现后需用真机器人验证**；不渲染则退化为纯文字，不影响功能。
+
 ### 4. 前端配置入口
 
-- 定时任务创建/编辑表单（`TasksView.vue` 及/或 `SiteSchedulesTab.vue`）加「告警」折叠区：
+- **两个入口都要改**（避免只改一处导致另一入口建的任务配不了告警）：定时任务创建/编辑表单在 `frontend/src/views/TasksView.vue`（约 289/297）与 `frontend/src/components/SiteSchedulesTab.vue`。加「告警」折叠区：
   - 开关 `alert_enabled`
   - webhook URL 输入 `alert_webhook`
   - 阈值数字框 `alert_threshold`（默认 90）
   - 「发送测试消息」按钮
-- 后端 `POST /api/schedules/{id}/alert-test`：用当前配置发一条测试飞书卡片，返回成功/失败，供前端验证 URL 通不通。
+- 后端 `POST /api/schedules/{id}/alert-test`：用当前配置发一条测试飞书卡片，返回成功/失败，供前端验证 URL 通不通。**必须照抄现有 schedules 路由的归属校验**（`Depends(get_current_user)` + `task_row["user_id"] != user_id` 拒绝，参 `server.py:2071-2078`）。
 - 创建/更新定时任务的端点扩展，接收并持久化这 3 个配置字段。
+- **输入校验**：`alert_threshold` 限 0–100；`alert_webhook` 非空时校验为合法 `https://` 飞书域名（与 SSRF 白名单一致），不合法则保存报错。
 
 ### 5. 错误处理
 
@@ -126,15 +150,23 @@
 ### 6. 测试策略
 
 - **`evaluate_alert` 纯函数单测**：ok→abnormal 发 alert、持续 abnormal 不发、abnormal→ok 发 recover、持续 ok 不发、边界（rate==threshold 视为正常）。
-- **`build_feishu_card` 单测**：alert 红头、recover 绿头、字段内容正确。
-- **`send_webhook` 单测**：mock aiohttp，验证 POST payload、超时/非 2xx 返回 False 不抛。
+- **成功率聚合单测**：跨多档并发/多 result 行正确累加（覆盖 level 清零 bug 的回归）；总请求=0 跳过。
+- **`build_feishu_card` 单测**：alert 红头、recover 绿头、字段内容正确、含 `wide_screen_mode`。
+- **SSRF 校验单测**：飞书域名放行；`localhost`/私网 IP/非飞书域名/http 一律拒绝。
+- **`send_webhook` 单测**：mock aiohttp，验证 POST payload、超时/非 2xx 返回 False 不抛、失败日志不含完整 URL。
 - 不依赖真实网络。
 
 ---
 
 ## 影响面
 
-- 改动文件：`app/db.py`（建表+迁移列）、`app/scheduler.py`（评估接入）、新增 `app/notifier.py`、`app/server.py`（任务 CRUD 扩展 + alert-test 端点）、前端 `TasksView.vue`/`SiteSchedulesTab.vue`、新增测试。
+- 改动文件：
+  - `app/db.py`：两处建表 DDL 加列、迁移加列、`create_scheduled_task` INSERT+签名、**`update_scheduled_task` allowlist 加 4 列**、新增 `get_run_success_rate(run_ids)` 助手。
+  - `app/scheduler.py`：`_run_scheduled_task` 末尾接入评估（用落库结果算成功率 + `evaluate_alert` + 写回 + 发卡片）。
+  - 新增 `app/notifier.py`：`build_feishu_card` / `send_webhook`（含 SSRF 校验 + 日志脱敏）。
+  - `app/server.py`：`create_schedule`/`update_schedule` 接收 alert 字段（**`update_schedule` allowlist 加 3 列** + 输入校验）、新增 `POST /api/schedules/{id}/alert-test`。
+  - 前端 `TasksView.vue` + `SiteSchedulesTab.vue`：告警配置区 + 测试按钮。
+  - 测试：`evaluate_alert` / 成功率聚合 / `build_feishu_card` / SSRF / `send_webhook`。
 - 向后兼容：新列均有默认值，存量任务 `alert_enabled=false` 不受影响。
 
 ---

--- a/docs/superpowers/specs/2026-06-04-scheduled-task-alerting-design.md
+++ b/docs/superpowers/specs/2026-06-04-scheduled-task-alerting-design.md
@@ -1,0 +1,142 @@
+# 定时拨测失败告警闭环 · 设计文档
+
+> 日期：2026-06-04
+> 关联：issue #30（F1，来自 `docs/2026-06-03-product-analysis-and-roadmap.md` 最高优先项）
+> 状态：设计已确认，待转 implementation plan
+
+---
+
+## 问题
+
+产品定位是「无人值守的 LLM 定时拨测 + 质量监控」，但告警**完全不闭环**：
+
+- 通知是纯前端内存态 `ref([])`（`frontend/src/composables/useNotifications.js:3`），刷新即丢。
+- 依赖「页面开着 + `ScheduleIndicator` 每 5 秒轮询侦测任务消失」才产生通知。
+- 后端无任何 webhook/邮件推送；`scheduler._run_scheduled_task` 任务失败只 `log_error`。
+
+结果：**关了浏览器，夜里渠道全挂也无人知晓。** 这是产品定位与实现差距最大的一处。
+
+## 目标
+
+- 定时拨测成功率低于阈值时，**主动推送告警到外部 IM**（无需用户开着页面）。
+- 渠道恢复时推送恢复通知。
+- 避免告警疲劳（拨测每 5 分钟一次，持续异常不刷屏）。
+
+## 非目标（YAGNI，留二期）
+
+- 邮件 / 多平台适配（v1 只做飞书 webhook）。
+- 延迟突增（P99 超阈值）等更多触发维度。
+- 告警历史持久化、重试队列。
+- 替换现有的前端内存通知中心（本功能与之并存，不动它）。
+
+---
+
+## 核心决策（已确认）
+
+| 维度 | 决定 |
+|---|---|
+| 通道 | 通用 Webhook，默认**飞书自定义机器人卡片**格式 |
+| 配置粒度 | **每个定时任务单独配**（webhook URL + 阈值 + 开关） |
+| 触发规则 | 成功率 < 阈值（默认 90%）视为异常；**仅状态翻转时推送**（正常→异常 发告警，异常→恢复 发恢复） |
+
+---
+
+## 设计
+
+### 1. 数据模型
+
+在 `scheduled_tasks` 表扩展 4 列（独立列而非塞进 `configs_json`，因 `alert_state` 每轮拨测后要更新）：
+
+| 列 | 类型 | 默认 | 用途 |
+|---|---|---|---|
+| `alert_webhook` | TEXT | `''` | 飞书机器人 webhook URL，空=不告警 |
+| `alert_threshold` | INTEGER | `90` | 成功率阈值（%），低于即异常 |
+| `alert_enabled` | INTEGER(SQLite)/BOOLEAN(PG) | false | 告警总开关 |
+| `alert_state` | TEXT | `'ok'` | 当前状态 `ok` / `alerting`，用于状态翻转去重 |
+
+迁移：SQLite 用 `ALTER TABLE ... ADD COLUMN`（沿用 `db.py` 现有列迁移模式，try/except 忽略已存在）；Postgres 用 `ADD COLUMN IF NOT EXISTS`。双模兼容。
+
+### 2. 触发评估
+
+挂在 `scheduler._run_scheduled_task` 完成处（`scheduler.py:350` 附近，已 `gather` 完所有 bench task）：
+
+1. **算成功率**：从 `manager.get_run_tasks(run_id)` 的 bench task 聚合 `success_rate = sum(success_count) / sum(total_count) * 100`（**百分比**，与 `alert_threshold` 同单位；运行中已维护这些字段，无需重查 DB）。
+   - **边界 `total_count == 0`**（任务因容量不足/无 profile 等没真正发出请求）：无法评估成功率，**跳过告警评估、不改 `alert_state`、记一条 log**。不把"没跑成"误判为成功或失败。
+2. **纯函数判定**：
+   ```python
+   def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> tuple[str, str | None]:
+       """返回 (新状态, 动作)。动作 ∈ {None, 'alert', 'recover'}。"""
+       abnormal = success_rate < threshold
+       if abnormal and prev_state == 'ok':
+           return 'alerting', 'alert'
+       if not abnormal and prev_state == 'alerting':
+           return 'ok', 'recover'
+       return prev_state, None   # 状态未翻转 → 不推送（防刷屏）
+   ```
+3. 按动作发卡片，并把新 `alert_state` 写回 DB。
+4. 整段包在 try/except——**告警失败绝不影响拨测主流程与重调度**。
+5. 仅当 `alert_enabled` 且 `alert_webhook` 非空时才评估。
+
+### 3. Webhook 推送（`app/notifier.py`）
+
+构造与发送分离，便于单测：
+
+- `build_feishu_card(kind, task_name, profile, rate, threshold, ts) -> dict`
+  - `kind='alert'`：红色头部 `template:"red"`，标题「🔴 拨测告警」，成功率红色。
+  - `kind='recover'`：绿色头部 `template:"green"`，标题「✅ 已恢复」，成功率绿色。
+- `async def send_webhook(url, payload, timeout=10) -> bool`
+  - aiohttp POST JSON，**best-effort**：超时/非 2xx/异常只 `log` 并返回 False，**不重试、不抛**。
+
+飞书卡片结构：
+
+```json
+{
+  "msg_type": "interactive",
+  "card": {
+    "header": { "template": "red", "title": {"tag":"plain_text","content":"🔴 拨测告警"} },
+    "elements": [
+      { "tag": "div", "fields": [
+        {"is_short": true, "text": {"tag":"lark_md","content":"**任务**\n<name>"}},
+        {"is_short": true, "text": {"tag":"lark_md","content":"**站点**\n<profile>"}},
+        {"is_short": true, "text": {"tag":"lark_md","content":"**成功率**\n<font color='red'>72%</font>"}},
+        {"is_short": true, "text": {"tag":"lark_md","content":"**阈值**\n90%"}}
+      ]},
+      { "tag": "hr" },
+      { "tag": "note", "elements": [{"tag":"lark_md","content":"⏰ 2026-06-04 10:30 · AITokenPerf"}] }
+    ]
+  }
+}
+```
+
+### 4. 前端配置入口
+
+- 定时任务创建/编辑表单（`TasksView.vue` 及/或 `SiteSchedulesTab.vue`）加「告警」折叠区：
+  - 开关 `alert_enabled`
+  - webhook URL 输入 `alert_webhook`
+  - 阈值数字框 `alert_threshold`（默认 90）
+  - 「发送测试消息」按钮
+- 后端 `POST /api/schedules/{id}/alert-test`：用当前配置发一条测试飞书卡片，返回成功/失败，供前端验证 URL 通不通。
+- 创建/更新定时任务的端点扩展，接收并持久化这 3 个配置字段。
+
+### 5. 错误处理
+
+- webhook 失败：`notifier.send_webhook` 吞掉异常、log、返回 False；不影响 `alert_state` 写回（即使推送失败也按判定结果更新状态，避免下轮重复尝试刷屏——可在文档注明此权衡）。
+- 评估逻辑异常：被 `_run_scheduled_task` 完成处的 try/except 兜住，记 `log_error`，拨测照常重调度。
+
+### 6. 测试策略
+
+- **`evaluate_alert` 纯函数单测**：ok→abnormal 发 alert、持续 abnormal 不发、abnormal→ok 发 recover、持续 ok 不发、边界（rate==threshold 视为正常）。
+- **`build_feishu_card` 单测**：alert 红头、recover 绿头、字段内容正确。
+- **`send_webhook` 单测**：mock aiohttp，验证 POST payload、超时/非 2xx 返回 False 不抛。
+- 不依赖真实网络。
+
+---
+
+## 影响面
+
+- 改动文件：`app/db.py`（建表+迁移列）、`app/scheduler.py`（评估接入）、新增 `app/notifier.py`、`app/server.py`（任务 CRUD 扩展 + alert-test 端点）、前端 `TasksView.vue`/`SiteSchedulesTab.vue`、新增测试。
+- 向后兼容：新列均有默认值，存量任务 `alert_enabled=false` 不受影响。
+
+---
+
+*实现前请对照当前代码复核 file:line（基于 2026-06-04 main）。*

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -58,6 +58,7 @@ export const getScheduleResults = (id, { limit = 100, offset = 0, hours } = {}) 
   return api(`/api/schedules/${id}/results?${params}`);
 };
 export const getScheduleTrend = (id, { hours } = {}) => api(`/api/schedules/${id}/trend` + (hours ? `?hours=${hours}` : ''));
+export const alertTestApi = (id) => api(`/api/schedules/${id}/alert-test`, { method: 'POST' });
 
 // Sites
 export const getSiteTrend = (profileName, { hours } = {}) => {

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -92,6 +92,25 @@
             <textarea class="form-input" v-model="createForm.user_prompt" rows="3" placeholder="Write a short essay about the future of artificial intelligence in exactly 200 words." maxlength="2000"></textarea>
           </div>
         </div>
+        <div class="form-grid" style="margin-top:12px">
+          <div class="form-group full">
+            <label class="form-switch">
+              <input type="checkbox" v-model="createForm.alert_enabled" />
+              <span>启用失败告警（飞书）</span>
+            </label>
+          </div>
+          <template v-if="createForm.alert_enabled">
+            <div class="form-group full">
+              <label class="form-label">飞书 Webhook URL</label>
+              <input class="form-input" v-model.trim="createForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+            </div>
+            <div class="form-group">
+              <label class="form-label">成功率阈值（%）</label>
+              <input class="form-input" type="number" v-model.number="createForm.alert_threshold" min="0" max="100" placeholder="90">
+              <div class="form-hint">上次运行成功率低于该值时触发告警；测试消息可在创建后编辑时发送</div>
+            </div>
+          </template>
+        </div>
         <div class="create-form-notice">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
           测试参数（并发、模式、超时等）可在创建后编辑
@@ -267,6 +286,31 @@
           <textarea class="form-input" v-model="editForm.user_prompt" rows="3" placeholder="Write a short essay..." maxlength="2000"></textarea>
         </div>
       </div>
+      <div class="form-grid" style="margin-top:12px">
+        <div class="form-group full">
+          <label class="form-switch">
+            <input type="checkbox" v-model="editForm.alert_enabled" />
+            <span>启用失败告警（飞书）</span>
+          </label>
+        </div>
+        <template v-if="editForm.alert_enabled">
+          <div class="form-group full">
+            <label class="form-label">飞书 Webhook URL</label>
+            <input class="form-input" v-model.trim="editForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+          </div>
+          <div class="form-group">
+            <label class="form-label">成功率阈值（%）</label>
+            <input class="form-input" type="number" v-model.number="editForm.alert_threshold" min="0" max="100" placeholder="90">
+            <div class="form-hint">上次运行成功率低于该值时触发告警</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">&nbsp;</label>
+            <button type="button" class="btn btn-ghost" :disabled="!editForm.alert_webhook || !editForm.id || alertTestLoading" @click="onTestAlert">
+              {{ alertTestLoading ? '发送中...' : '发送测试消息' }}
+            </button>
+          </div>
+        </template>
+      </div>
       <div class="btn-group" style="margin-top:20px">
         <button class="btn btn-primary" @click="saveEdit" :disabled="editLoading">
           <span v-if="!editLoading">保存</span>
@@ -288,6 +332,7 @@ import {
   pauseScheduleApi,
   resumeScheduleApi,
   runNowApi,
+  alertTestApi,
 } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import InlineConfirmDelete from './InlineConfirmDelete.vue';
@@ -305,6 +350,7 @@ const createLoading = ref(false);
 const deleteCandidate = ref(null);
 const showEditForm = ref(false);
 const editLoading = ref(false);
+const alertTestLoading = ref(false);
 
 // ---- Profile data ----
 const profileModels = computed(() => {
@@ -337,6 +383,9 @@ function defaultCreateForm() {
     duration: 120,
     system_prompt: 'You are a helpful assistant.',
     user_prompt: 'Write a short essay about the future of artificial intelligence in exactly 200 words.',
+    alert_enabled: false,
+    alert_webhook: '',
+    alert_threshold: 90,
   };
 }
 
@@ -374,6 +423,9 @@ const editForm = ref({
   duration: 120,
   system_prompt: '',
   user_prompt: '',
+  alert_enabled: false,
+  alert_webhook: '',
+  alert_threshold: 90,
 });
 
 // ---- Multi-model select ----
@@ -448,6 +500,9 @@ function startEdit(s) {
     duration: configs.duration || 120,
     system_prompt: configs.system_prompt || '',
     user_prompt: configs.user_prompt || '',
+    alert_enabled: !!s.alert_enabled,
+    alert_webhook: s.alert_webhook || '',
+    alert_threshold: s.alert_threshold != null ? s.alert_threshold : 90,
   };
   // Detect preset or custom
   const sv = String(s.schedule_value);
@@ -549,6 +604,9 @@ async function createSchedule() {
       },
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
+      alert_enabled: !!f.alert_enabled,
+      alert_webhook: f.alert_webhook || '',
+      alert_threshold: parseInt(f.alert_threshold) || 0,
     };
     const res = await createScheduleApi(payload);
     if (res.error) {
@@ -593,6 +651,9 @@ async function saveEdit() {
       configs_json: configs,
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
+      alert_enabled: !!f.alert_enabled,
+      alert_webhook: f.alert_webhook || '',
+      alert_threshold: parseInt(f.alert_threshold) || 0,
     });
     if (res.error) {
       toast(res.error, 'error');
@@ -605,6 +666,19 @@ async function saveEdit() {
     toast('更新失败: ' + e.message, 'error');
   }
   editLoading.value = false;
+}
+
+async function onTestAlert() {
+  const id = editForm.value.id;
+  if (!id) return;
+  alertTestLoading.value = true;
+  try {
+    const r = await alertTestApi(id);
+    toast(r.ok ? '测试消息已发送，请检查飞书' : '发送失败，请检查 URL', r.ok ? 'success' : 'error');
+  } catch (e) {
+    toast('发送失败：' + (e.message || e), 'error');
+  }
+  alertTestLoading.value = false;
 }
 
 async function pauseSchedule(id) {
@@ -862,6 +936,24 @@ onUnmounted(() => {
 /* ---- Edit Form (Modal) ---- */
 .site-schedules-tab .form-grid .full {
   grid-column: 1 / -1;
+}
+
+/* ---- Alert Switch ---- */
+.form-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.form-switch input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--accent);
 }
 
 /* ---- Responsive ---- */

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -606,7 +606,7 @@ async function createSchedule() {
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
       alert_webhook: f.alert_webhook || '',
-      alert_threshold: parseInt(f.alert_threshold) || 0,
+      alert_threshold: parseInt(f.alert_threshold) || 90,
     };
     const res = await createScheduleApi(payload);
     if (res.error) {
@@ -653,7 +653,7 @@ async function saveEdit() {
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
       alert_webhook: f.alert_webhook || '',
-      alert_threshold: parseInt(f.alert_threshold) || 0,
+      alert_threshold: parseInt(f.alert_threshold) || 90,
     });
     if (res.error) {
       toast(res.error, 'error');

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -510,7 +510,7 @@ async function createSchedule() {
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
       alert_webhook: f.alert_webhook || '',
-      alert_threshold: parseInt(f.alert_threshold) || 0,
+      alert_threshold: parseInt(f.alert_threshold) || 90,
     };
     const res = await createScheduleApi(payload);
     if (res.error) {

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -221,6 +221,32 @@
           </div>
         </div>
       </div>
+      <!-- 失败告警（折叠） -->
+      <div class="advanced-section">
+        <button class="advanced-toggle" @click="showAlert = !showAlert">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          失败告警
+          <svg class="advanced-chevron" :class="{ open: showAlert }" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 4.5l3 3 3-3"/></svg>
+        </button>
+        <div class="advanced-body" v-show="showAlert">
+          <label class="form-switch">
+            <input type="checkbox" v-model="createForm.alert_enabled" />
+            <span>启用失败告警（飞书）</span>
+          </label>
+          <div class="create-modal-grid" v-if="createForm.alert_enabled" style="grid-template-columns:1fr;margin-top:12px">
+            <div class="form-group">
+              <label class="form-label">飞书 Webhook URL</label>
+              <input class="form-input" v-model.trim="createForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+            </div>
+            <div class="form-group">
+              <label class="form-label">成功率阈值（%）</label>
+              <input class="form-input" type="number" v-model.number="createForm.alert_threshold" min="0" max="100" placeholder="90" style="width:120px">
+              <div class="form-hint">上次运行成功率低于该值时触发告警</div>
+            </div>
+            <div class="form-hint">测试消息需先保存任务，可在站点详情页编辑任务时发送测试</div>
+          </div>
+        </div>
+      </div>
       <div class="btn-group" style="margin-top:20px">
         <button class="btn btn-primary" @click="createSchedule" :disabled="createLoading">
           {{ createLoading ? '创建中...' : '创建' }}
@@ -286,15 +312,16 @@ function handleDocClick(e) {
 }
 
 function resetCreateForm() {
-  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120 };
+  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_webhook: '', alert_threshold: 90 };
   frequencyPreset.value = '300';
   profileDropdownOpen.value = false;
   freqDropdownOpen.value = false;
   modelDropdownOpen.value = false;
   showAdvanced.value = false;
+  showAlert.value = false;
 }
 
-const createForm = ref({ name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120 });
+const createForm = ref({ name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_webhook: '', alert_threshold: 90 });
 
 const selectedProfileModels = computed(() => {
   const p = profiles.value.find(p => p.name === createForm.value.profile_name);
@@ -326,6 +353,7 @@ function selectFrequency(value) {
 
 const modelSearch = ref('');
 const showAdvanced = ref(false);
+const showAlert = ref(false);
 
 const filteredTaskModels = computed(() => {
   const q = (modelSearch.value || '').toLowerCase();
@@ -480,6 +508,9 @@ async function createSchedule() {
       },
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
+      alert_enabled: !!f.alert_enabled,
+      alert_webhook: f.alert_webhook || '',
+      alert_threshold: parseInt(f.alert_threshold) || 0,
     };
     const res = await createScheduleApi(payload);
     if (res.error) {
@@ -750,6 +781,24 @@ onUnmounted(() => { store.refreshFn = null; document.removeEventListener('moused
 .advanced-body {
   padding: 14px;
   border-top: 1px solid var(--border-subtle);
+}
+
+/* ---- Alert Switch ---- */
+.form-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.form-switch input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--accent);
 }
 
 @media (max-width: 768px) {

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -1,0 +1,46 @@
+import pytest
+from tests.conftest import auth_headers
+from app.db import get_scheduled_task
+
+
+async def _make_profile(client, headers):
+    await client.post("/api/profiles/save", json={
+        "name": "s", "base_url": "https://api.example.com", "api_key": "sk-x",
+        "api_key_action": "replace", "models": ["gpt-4o-mini"], "provider": "openai",
+    }, headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_with_alert(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_threshold": 85,
+        "alert_webhook": "https://open.feishu.cn/x",
+    }, headers=headers)
+    assert resp.status_code == 200
+    sid = resp.json()["id"]
+    row = await get_scheduled_task(sid)
+    assert row["alert_threshold"] == 85
+    assert row["alert_webhook"] == "https://open.feishu.cn/x"
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_bad_webhook(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_webhook": "https://evil.com/x",
+    }, headers=headers)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_bad_threshold(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_threshold": 250,
+    }, headers=headers)
+    assert resp.status_code == 400

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -71,6 +71,26 @@ async def test_alert_test_endpoint(client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_alert_test_rejects_other_user(client):
+    from tests.conftest import login_and_get_token
+    headers_a = await auth_headers(client)
+    await _make_profile(client, headers_a)
+    sid = (await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_enabled": True,
+        "alert_webhook": "https://open.feishu.cn/x",
+    }, headers=headers_a)).json()["id"]
+
+    await client.post("/api/auth/register", json={
+        "email": "other@example.com", "password": "AITokenPerf#123", "display_name": "B",
+    })
+    token_b = await login_and_get_token(client, "other@example.com", "AITokenPerf#123")
+    headers_b = {"Authorization": f"Bearer {token_b}"}
+
+    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers_b)
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_alert_test_requires_webhook(client):
     headers = await auth_headers(client)
     await _make_profile(client, headers)

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -1,6 +1,7 @@
 import pytest
 from tests.conftest import auth_headers
 from app.db import get_scheduled_task
+from app import notifier
 
 
 async def _make_profile(client, headers):
@@ -44,3 +45,36 @@ async def test_create_schedule_rejects_bad_threshold(client):
         "name": "t", "profile_ids": ["s"], "alert_threshold": 250,
     }, headers=headers)
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_alert_test_endpoint(client, monkeypatch):
+    sent = []
+
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(url)
+        return True
+
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "alert_enabled": True,
+        "alert_webhook": "https://open.feishu.cn/x",
+    }, headers=headers)
+    sid = resp.json()["id"]
+
+    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_alert_test_requires_webhook(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={"name": "t", "profile_ids": ["s"]}, headers=headers)
+    sid = resp.json()["id"]
+    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
+    assert r.status_code == 400

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -1,0 +1,49 @@
+import json
+
+import pytest
+
+from app.db import (
+    create_scheduled_task,
+    get_scheduled_task,
+    update_scheduled_task,
+    save_result,
+    get_run_success_rate,
+)
+
+
+@pytest.mark.asyncio
+async def test_alert_fields_roundtrip():
+    sid = await create_scheduled_task(
+        1, "t", [], {}, "interval", "300",
+        alert_webhook="https://open.feishu.cn/x", alert_threshold=80, alert_enabled=True,
+    )
+    row = await get_scheduled_task(sid)
+    assert row["alert_webhook"] == "https://open.feishu.cn/x"
+    assert row["alert_threshold"] == 80
+    assert bool(row["alert_enabled"]) is True
+    assert row["alert_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_update_alert_state_persists():
+    sid = await create_scheduled_task(1, "t2", [], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_state="alerting")
+    row = await get_scheduled_task(sid)
+    assert row["alert_state"] == "alerting"
+
+
+@pytest.mark.asyncio
+async def test_get_run_success_rate_aggregates():
+    for i, (succ, tot) in enumerate([(8, 10), (5, 10)]):
+        await save_result(
+            user_id=1, test_id=f"t{i}", filename=f"f{i}.json", timestamp="20260604_120000",
+            config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-x",
+        )
+    assert await get_run_success_rate(["run-x"]) == (13, 20)
+
+
+@pytest.mark.asyncio
+async def test_get_run_success_rate_empty():
+    assert await get_run_success_rate([]) == (0, 0)
+    assert await get_run_success_rate(["nope"]) == (0, 0)

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -25,6 +25,18 @@ async def test_alert_fields_roundtrip():
 
 
 @pytest.mark.asyncio
+async def test_update_alert_enabled_roundtrip():
+    sid = await create_scheduled_task(1, "t3", [], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_enabled=True, alert_webhook="https://open.feishu.cn/y")
+    row = await get_scheduled_task(sid)
+    assert bool(row["alert_enabled"]) is True
+    assert row["alert_webhook"] == "https://open.feishu.cn/y"
+    await update_scheduled_task(sid, alert_enabled=False)
+    row2 = await get_scheduled_task(sid)
+    assert bool(row2["alert_enabled"]) is False
+
+
+@pytest.mark.asyncio
 async def test_update_alert_state_persists():
     sid = await create_scheduled_task(1, "t2", [], {}, "interval", "300")
     await update_scheduled_task(sid, alert_state="alerting")

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -1,0 +1,64 @@
+import json
+
+import pytest
+
+from app import notifier, scheduler
+from app.db import create_scheduled_task, save_result, get_scheduled_task, update_scheduled_task
+
+
+async def _seed(rate_pair, alert_state="ok", enabled=True):
+    succ, tot = rate_pair
+    sid = await create_scheduled_task(
+        1, "t", ["SiteA"], {}, "interval", "300",
+        alert_webhook="https://open.feishu.cn/x", alert_threshold=90, alert_enabled=enabled,
+    )
+    if alert_state != "ok":
+        await update_scheduled_task(sid, alert_state=alert_state)
+    await save_result(
+        user_id=1, test_id="a", filename="a.json", timestamp="20260604_120000",
+        config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+        percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_alert_fires_and_writes_state(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((5, 10))  # 50% < 90%
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+
+    assert len(sent) == 1
+    assert (await get_scheduled_task(sid))["alert_state"] == "alerting"
+
+
+@pytest.mark.asyncio
+async def test_no_alert_when_disabled(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((5, 10), enabled=False)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_recover_when_back_to_normal(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await _seed((10, 10), alert_state="alerting")  # 100% >= 90%, 之前告警中
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 1
+    assert (await get_scheduled_task(sid))["alert_state"] == "ok"

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -51,6 +51,24 @@ async def test_no_alert_when_disabled(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_no_alert_when_no_results(monkeypatch):
+    # 本轮无有效请求（run_ids 无对应 result 行）→ total==0，跳过评估、不发、不改状态
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload); return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+
+    sid = await create_scheduled_task(
+        1, "t", ["SiteA"], {}, "interval", "300",
+        alert_webhook="https://open.feishu.cn/x", alert_threshold=90, alert_enabled=True,
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-empty"])
+    assert sent == []
+    assert (await get_scheduled_task(sid))["alert_state"] == "ok"
+
+
+@pytest.mark.asyncio
 async def test_recover_when_back_to_normal(monkeypatch):
     sent = []
     async def fake_send(url, payload, timeout=10.0):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -63,3 +63,42 @@ def test_recover_card_green_header():
     card = build_feishu_card("recover", "主力渠道", "OpenAI-A", 95.0, 90, "2026-06-04 10:30")
     assert card["card"]["header"]["template"] == "green"
     assert "恢复" in card["card"]["header"]["title"]["content"]
+
+
+import pytest
+from app import notifier
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_rejects_ssrf():
+    assert await notifier.send_webhook("https://evil.com/x", {"a": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_success(monkeypatch):
+    class FakeResp:
+        status = 200
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+    class FakeSession:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def post(self, *a, **k): return FakeResp()
+    monkeypatch.setattr(notifier.aiohttp, "ClientSession", FakeSession)
+    assert await notifier.send_webhook("https://open.feishu.cn/open-apis/bot/v2/hook/x", {"a": 1}) is True
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_non_2xx_returns_false(monkeypatch):
+    class FakeResp:
+        status = 500
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+    class FakeSession:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def post(self, *a, **k): return FakeResp()
+    monkeypatch.setattr(notifier.aiohttp, "ClientSession", FakeSession)
+    assert await notifier.send_webhook("https://open.feishu.cn/x", {"a": 1}) is False

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,4 +1,4 @@
-from app.notifier import evaluate_alert
+from app.notifier import evaluate_alert, is_allowed_webhook
 
 
 def test_alert_fires_on_ok_to_abnormal():
@@ -19,3 +19,31 @@ def test_no_action_while_ok():
 
 def test_threshold_boundary_is_normal():
     assert evaluate_alert("ok", 90.0, 90) == ("ok", None)
+
+
+def test_feishu_https_allowed():
+    assert is_allowed_webhook("https://open.feishu.cn/open-apis/bot/v2/hook/xxx") is True
+
+
+def test_larksuite_allowed():
+    assert is_allowed_webhook("https://open.larksuite.com/open-apis/bot/v2/hook/xxx") is True
+
+
+def test_http_rejected():
+    assert is_allowed_webhook("http://open.feishu.cn/x") is False
+
+
+def test_localhost_rejected():
+    assert is_allowed_webhook("https://localhost/x") is False
+
+
+def test_internal_ip_rejected():
+    assert is_allowed_webhook("https://169.254.169.254/latest/meta-data") is False
+
+
+def test_other_domain_rejected():
+    assert is_allowed_webhook("https://evil.com/x") is False
+
+
+def test_empty_rejected():
+    assert is_allowed_webhook("") is False

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,21 @@
+from app.notifier import evaluate_alert
+
+
+def test_alert_fires_on_ok_to_abnormal():
+    assert evaluate_alert("ok", 72.0, 90) == ("alerting", "alert")
+
+
+def test_no_repeat_while_abnormal():
+    assert evaluate_alert("alerting", 50.0, 90) == ("alerting", None)
+
+
+def test_recover_on_abnormal_to_ok():
+    assert evaluate_alert("alerting", 95.0, 90) == ("ok", "recover")
+
+
+def test_no_action_while_ok():
+    assert evaluate_alert("ok", 99.0, 90) == ("ok", None)
+
+
+def test_threshold_boundary_is_normal():
+    assert evaluate_alert("ok", 90.0, 90) == ("ok", None)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,4 +1,4 @@
-from app.notifier import evaluate_alert, is_allowed_webhook
+from app.notifier import build_feishu_card, evaluate_alert, is_allowed_webhook
 
 
 def test_alert_fires_on_ok_to_abnormal():
@@ -47,3 +47,19 @@ def test_other_domain_rejected():
 
 def test_empty_rejected():
     assert is_allowed_webhook("") is False
+
+
+def test_alert_card_red_header():
+    card = build_feishu_card("alert", "主力渠道", "OpenAI-A", 72.0, 90, "2026-06-04 10:30")
+    assert card["msg_type"] == "interactive"
+    assert card["card"]["config"]["wide_screen_mode"] is True
+    assert card["card"]["header"]["template"] == "red"
+    assert "告警" in card["card"]["header"]["title"]["content"]
+    flat = str(card)
+    assert "72.0%" in flat and "90%" in flat and "主力渠道" in flat
+
+
+def test_recover_card_green_header():
+    card = build_feishu_card("recover", "主力渠道", "OpenAI-A", 95.0, 90, "2026-06-04 10:30")
+    assert card["card"]["header"]["template"] == "green"
+    assert "恢复" in card["card"]["header"]["title"]["content"]

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,3 +1,6 @@
+import pytest
+
+from app import notifier
 from app.notifier import build_feishu_card, evaluate_alert, is_allowed_webhook
 
 
@@ -63,10 +66,6 @@ def test_recover_card_green_header():
     card = build_feishu_card("recover", "主力渠道", "OpenAI-A", 95.0, 90, "2026-06-04 10:30")
     assert card["card"]["header"]["template"] == "green"
     assert "恢复" in card["card"]["header"]["title"]["content"]
-
-
-import pytest
-from app import notifier
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
拨测成功率低于阈值时主动推送**飞书卡片告警**（含恢复通知），无需用户开着页面。

- 每个定时任务单独配 webhook + 阈值（scheduled_tasks 加 4 列）
- 成功率从**落库结果**聚合（绕开被并发档清零的内存计数）
- 状态机仅**状态翻转**时推送（正常↔异常），防刷屏；红/绿头飞书卡片
- **SSRF 防护**：webhook 仅限 https 飞书域名（保存+发送双重校验）；日志脱敏
- best-effort：告警失败不影响拨测主流程/重调度；多 worker 由 claim 锁保证不重复
- 前端 TasksView + SiteSchedulesTab 告警配置区 + 发送测试按钮

Closes #30

## Test plan
- [x] 后端全量 252 passed
- [x] 前端 bun run build 通过
- [ ] 真机：飞书 webhook 收红色告警/绿色恢复卡片，验证 font color 渲染