### PR TITLE
重构：飞书告警解耦为可复用「告警器」(#33)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1295,7 +1295,7 @@ async def update_scheduled_task(task_id: int, **fields):
     async with engine.begin() as conn:
         allowed = {"name", "profile_ids", "configs_json", "schedule_type",
                    "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
-                   "alert_webhook", "alert_threshold", "alert_enabled", "alert_state",
+                   "alert_threshold", "alert_enabled", "alert_state",
                    "alert_notifier_id"}
         set_parts = []
         values = {"id": task_id}

--- a/app/db.py
+++ b/app/db.py
@@ -640,6 +640,81 @@ async def delete_profile(user_id: int, name: str):
         )
 
 
+# ---- Notifiers CRUD ----
+
+def _row_to_notifier(row) -> dict:
+    return dict(row._mapping)
+
+
+async def create_notifier(user_id: int, name: str, webhook: str,
+                          type: str = "feishu") -> int:
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("""INSERT INTO notifiers (user_id, name, type, webhook)
+                   VALUES (:uid, :name, :type, :wh)"""),
+            {"uid": user_id, "name": name, "type": type, "wh": webhook},
+        )
+        if _is_sqlite:
+            return cur.lastrowid
+        result = await conn.execute(text("SELECT lastval()"))
+        return (result.fetchone())[0]
+
+
+async def list_notifiers(user_id: int) -> list[dict]:
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text("SELECT * FROM notifiers WHERE user_id=:uid ORDER BY id"),
+            {"uid": user_id},
+        )
+        return [_row_to_notifier(r) for r in cur.fetchall()]
+
+
+async def get_notifier(notifier_id: int) -> Optional[dict]:
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text("SELECT * FROM notifiers WHERE id=:id"), {"id": notifier_id}
+        )
+        row = cur.fetchone()
+        return _row_to_notifier(row) if row else None
+
+
+async def update_notifier(notifier_id: int, **fields):
+    async with engine.begin() as conn:
+        allowed = {"name", "webhook", "type"}
+        set_parts = []
+        values = {"id": notifier_id}
+        for k, v in fields.items():
+            if k not in allowed:
+                continue
+            if k == "webhook" and (v is None or v == ""):
+                continue  # 留空 = 不改 webhook（避免覆盖成空）
+            set_parts.append(f"{k}=:{k}")
+            values[k] = v
+        if not set_parts:
+            return
+        set_parts.append(f"updated_at={_now_sql()}")
+        await conn.execute(
+            text(f"UPDATE notifiers SET {', '.join(set_parts)} WHERE id=:id"),
+            values,
+        )
+
+
+async def delete_notifier(notifier_id: int) -> tuple[bool, int]:
+    """同事务内先查引用再删，避免 TOCTOU。返回 (是否已删, 引用任务数)。"""
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("SELECT COUNT(*) FROM scheduled_tasks WHERE alert_notifier_id=:id"),
+            {"id": notifier_id},
+        )
+        refs = (cur.fetchone())[0]
+        if refs > 0:
+            return False, refs
+        await conn.execute(
+            text("DELETE FROM notifiers WHERE id=:id"), {"id": notifier_id}
+        )
+        return True, 0
+
+
 # ---- Results CRUD ----
 
 async def save_result(user_id: int, test_id: str, filename: str, timestamp: str,
@@ -1224,7 +1299,8 @@ async def update_scheduled_task(task_id: int, **fields):
     async with engine.begin() as conn:
         allowed = {"name", "profile_ids", "configs_json", "schedule_type",
                    "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
-                   "alert_webhook", "alert_threshold", "alert_enabled", "alert_state"}
+                   "alert_webhook", "alert_threshold", "alert_enabled", "alert_state",
+                   "alert_notifier_id"}
         set_parts = []
         values = {"id": task_id}
         for k, v in fields.items():

--- a/app/db.py
+++ b/app/db.py
@@ -136,6 +136,17 @@ CREATE TABLE IF NOT EXISTS channel_diagnostics (
     report_json   TEXT NOT NULL DEFAULT '{}',
     created_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS notifiers (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    type       TEXT NOT NULL DEFAULT 'feishu',
+    webhook    TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(user_id, name)
+);
 """
 
 # PostgreSQL schema
@@ -235,6 +246,17 @@ CREATE TABLE IF NOT EXISTS channel_diagnostics (
     report_json   TEXT NOT NULL DEFAULT '{}',
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS notifiers (
+    id         SERIAL PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    type       TEXT NOT NULL DEFAULT 'feishu',
+    webhook    TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, name)
+);
 """
 
 # PG 需要的辅助索引（email 大小写不敏感）
@@ -315,6 +337,7 @@ async def init_db():
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_threshold INTEGER NOT NULL DEFAULT 90",
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_enabled INTEGER NOT NULL DEFAULT 0",
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_state TEXT NOT NULL DEFAULT 'ok'",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_notifier_id INTEGER NOT NULL DEFAULT 0",
             ]:
                 try:
                     await conn.execute(text(col_def))
@@ -326,6 +349,7 @@ async def init_db():
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_threshold INTEGER NOT NULL DEFAULT 90",
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE",
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_state TEXT NOT NULL DEFAULT 'ok'",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_notifier_id INTEGER NOT NULL DEFAULT 0",
             ]:
                 await conn.execute(text(col_def))
 

--- a/app/db.py
+++ b/app/db.py
@@ -642,10 +642,6 @@ async def delete_profile(user_id: int, name: str):
 
 # ---- Notifiers CRUD ----
 
-def _row_to_notifier(row) -> dict:
-    return dict(row._mapping)
-
-
 async def create_notifier(user_id: int, name: str, webhook: str,
                           type: str = "feishu") -> int:
     async with engine.begin() as conn:
@@ -666,7 +662,7 @@ async def list_notifiers(user_id: int) -> list[dict]:
             text("SELECT * FROM notifiers WHERE user_id=:uid ORDER BY id"),
             {"uid": user_id},
         )
-        return [_row_to_notifier(r) for r in cur.fetchall()]
+        return _rows_to_dicts(cur.fetchall())
 
 
 async def get_notifier(notifier_id: int) -> Optional[dict]:
@@ -675,7 +671,7 @@ async def get_notifier(notifier_id: int) -> Optional[dict]:
             text("SELECT * FROM notifiers WHERE id=:id"), {"id": notifier_id}
         )
         row = cur.fetchone()
-        return _row_to_notifier(row) if row else None
+        return _row_to_dict(row) if row else None
 
 
 async def update_notifier(notifier_id: int, **fields):

--- a/app/db.py
+++ b/app/db.py
@@ -1220,17 +1220,17 @@ async def save_settings(user_id: int, benchmark: dict, output_dir: str = "./resu
 
 async def create_scheduled_task(user_id: int, name: str, profile_ids: list,
                                  configs_json: dict, schedule_type: str,
-                                 schedule_value: str, alert_webhook: str = "",
+                                 schedule_value: str, alert_notifier_id: int = 0,
                                  alert_threshold: int = 90,
                                  alert_enabled: bool = False) -> int:
     async with engine.begin() as conn:
         cur = await conn.execute(
             text("""INSERT INTO scheduled_tasks (user_id, name, profile_ids, configs_json,
-                    schedule_type, schedule_value, alert_webhook, alert_threshold, alert_enabled)
-                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :aw, :at, :ae)"""),
+                    schedule_type, schedule_value, alert_notifier_id, alert_threshold, alert_enabled)
+                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :ani, :at, :ae)"""),
             {"uid": user_id, "name": name, "pids": json.dumps(profile_ids),
              "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value,
-             "aw": alert_webhook, "at": alert_threshold,
+             "ani": alert_notifier_id, "at": alert_threshold,
              "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled)},
         )
         if _is_sqlite:

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -226,11 +226,17 @@ class TaskScheduler:
 
 async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
-    from app.db import get_run_success_rate
+    from app.db import get_run_success_rate, get_notifier
     # notifier 在函数内 import：保持 send_webhook 在调用时解析，便于测试 monkeypatch
     from app.notifier import evaluate_alert, build_feishu_card, send_webhook
 
-    if not task_row.get("alert_enabled") or not (task_row.get("alert_webhook") or "").strip():
+    notifier_id = task_row.get("alert_notifier_id") or 0
+    if not task_row.get("alert_enabled") or not notifier_id:
+        return  # 未开启 或 未选告警器：不发、不报错
+    ntf = await get_notifier(notifier_id)
+    webhook = (ntf or {}).get("webhook", "").strip() if ntf else ""
+    if not webhook:
+        log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
         return
     success, total = await get_run_success_rate(run_ids)
     if total == 0:
@@ -244,7 +250,7 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
         profiles_text = ", ".join(task_row.get("profile_ids", []) or []) or "-"
         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         card = build_feishu_card(action, task_row.get("name", ""), profiles_text, rate, threshold, ts)
-        await send_webhook(task_row["alert_webhook"], card)
+        await send_webhook(webhook, card)
     if new_state != prev:
         await update_scheduled_task(task_id, alert_state=new_state)
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -234,7 +234,7 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     if not task_row.get("alert_enabled") or not notifier_id:
         return  # 未开启 或 未选告警器：不发、不报错
     ntf = await get_notifier(notifier_id)
-    webhook = (ntf or {}).get("webhook", "").strip() if ntf else ""
+    webhook = (ntf or {}).get("webhook", "").strip()
     if not webhook:
         log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
         return

--- a/app/server.py
+++ b/app/server.py
@@ -2025,9 +2025,9 @@ async def list_schedules(user: dict = Depends(get_current_user)):
     return {"schedules": tasks}
 
 
-def _extract_alert_fields(body: dict):
+async def _extract_alert_fields(body: dict, user_id: int):
     """从请求体提取并校验告警字段。返回 (fields, error)。error 非空表示校验失败。"""
-    from app.notifier import is_allowed_webhook
+    from app.db import get_notifier
     out = {}
     if "alert_enabled" in body:
         out["alert_enabled"] = bool(body["alert_enabled"])
@@ -2039,12 +2039,30 @@ def _extract_alert_fields(body: dict):
         if not (0 <= t <= 100):
             return None, "alert_threshold 必须在 0-100 之间"
         out["alert_threshold"] = t
-    if "alert_webhook" in body:
-        wh = (body.get("alert_webhook") or "").strip()
-        if wh and not is_allowed_webhook(wh):
-            return None, "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"
-        out["alert_webhook"] = wh
+    if "alert_notifier_id" in body:
+        try:
+            nid = int(body.get("alert_notifier_id") or 0)
+        except (ValueError, TypeError):
+            return None, "alert_notifier_id 非法"
+        if nid:
+            n = await get_notifier(nid)
+            if not n or n["user_id"] != user_id:
+                return None, "告警器不存在或无权使用"
+        out["alert_notifier_id"] = nid
     return out, None
+
+
+def _mask_webhook(url: str) -> str:
+    """脱敏：保留 host + 尾 4 位，其余打码。不回明文全量。"""
+    from urllib.parse import urlparse
+    if not url:
+        return ""
+    try:
+        p = urlparse(url)
+        tail = url[-4:] if len(url) > 4 else ""
+        return f"https://{p.hostname}/***{tail}"
+    except Exception:
+        return "***"
 
 
 @app.post("/api/schedules")
@@ -2082,13 +2100,13 @@ async def create_schedule(request: Request, user: dict = Depends(get_current_use
     if sv_int < 60:
         return JSONResponse({"error": "定时任务间隔不能小于 60 秒"}, status_code=400)
 
-    alert_fields, alert_err = _extract_alert_fields(body)
+    alert_fields, alert_err = await _extract_alert_fields(body, user_id)
     if alert_err:
         return JSONResponse({"error": alert_err}, status_code=400)
 
     sid = await create_scheduled_task(
         user_id, name, profile_ids, configs_json, schedule_type, schedule_value,
-        alert_webhook=alert_fields.get("alert_webhook", ""),
+        alert_notifier_id=alert_fields.get("alert_notifier_id", 0),
         alert_threshold=alert_fields.get("alert_threshold", 90),
         alert_enabled=alert_fields.get("alert_enabled", False),
     )
@@ -2121,7 +2139,7 @@ async def update_schedule(task_id: int, request: Request, user: dict = Depends(g
         if sv_int < 60:
             return JSONResponse({"error": "定时任务间隔不能小于 60 秒"}, status_code=400)
 
-    alert_fields, alert_err = _extract_alert_fields(body)
+    alert_fields, alert_err = await _extract_alert_fields(body, user_id)
     if alert_err:
         return JSONResponse({"error": alert_err}, status_code=400)
     fields.update(alert_fields)
@@ -2202,21 +2220,85 @@ async def run_schedule_now(task_id: int, user: dict = Depends(get_current_user))
     return {"status": "triggered"}
 
 
-@app.post("/api/schedules/{task_id}/alert-test")
-async def alert_test(task_id: int, user: dict = Depends(get_current_user)):
-    from app.db import get_scheduled_task
+@app.get("/api/notifiers")
+async def list_notifiers_endpoint(user: dict = Depends(get_current_user)):
+    from app.db import list_notifiers
+    items = await list_notifiers(user["user_id"])
+    return [
+        {"id": n["id"], "name": n["name"], "type": n["type"],
+         "webhook": _mask_webhook(n["webhook"])}
+        for n in items
+    ]
+
+
+@app.post("/api/notifiers")
+async def create_notifier_endpoint(request: Request, user: dict = Depends(get_current_user)):
+    from app.db import create_notifier
+    from app.notifier import is_allowed_webhook
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    webhook = (body.get("webhook") or "").strip()
+    if not name:
+        return JSONResponse({"error": "名称不能为空"}, status_code=400)
+    if not is_allowed_webhook(webhook):
+        return JSONResponse({"error": "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"}, status_code=400)
+    try:
+        nid = await create_notifier(user["user_id"], name, webhook)
+    except Exception:
+        return JSONResponse({"error": "创建失败：名称可能重复"}, status_code=400)
+    return {"id": nid, "status": "created"}
+
+
+@app.put("/api/notifiers/{notifier_id}")
+async def update_notifier_endpoint(notifier_id: int, request: Request,
+                                   user: dict = Depends(get_current_user)):
+    from app.db import get_notifier, update_notifier
+    from app.notifier import is_allowed_webhook
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    body = await request.json()
+    fields = {}
+    if "name" in body:
+        nm = (body.get("name") or "").strip()
+        if not nm:
+            return JSONResponse({"error": "名称不能为空"}, status_code=400)
+        fields["name"] = nm
+    if "webhook" in body:
+        wh = (body.get("webhook") or "").strip()
+        if wh and not is_allowed_webhook(wh):
+            return JSONResponse({"error": "webhook 必须是 https 的飞书域名"}, status_code=400)
+        fields["webhook"] = wh  # 空串 = 不改（db 层 update_notifier 已处理）
+    await update_notifier(notifier_id, **fields)
+    return {"status": "updated"}
+
+
+@app.delete("/api/notifiers/{notifier_id}")
+async def delete_notifier_endpoint(notifier_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_notifier, delete_notifier
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    ok, refs = await delete_notifier(notifier_id)
+    if not ok:
+        return JSONResponse({"error": f"还有 {refs} 个任务在用，先解绑再删", "refs": refs}, status_code=409)
+    return {"status": "deleted"}
+
+
+@app.post("/api/notifiers/{notifier_id}/test")
+async def notifier_test(notifier_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_notifier
     # notifier 函数内 import：保持 send_webhook 调用时解析，便于测试 monkeypatch，勿上移顶部
     from app.notifier import build_feishu_card, send_webhook, is_allowed_webhook
     from datetime import datetime
-    task_row = await get_scheduled_task(task_id)
-    if not task_row or task_row["user_id"] != user["user_id"]:
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
         return JSONResponse({"error": "Not found"}, status_code=404)
-    webhook = (task_row.get("alert_webhook") or "").strip()
+    webhook = (n.get("webhook") or "").strip()
     if not webhook or not is_allowed_webhook(webhook):
-        return JSONResponse({"error": "请先配置合法的飞书 webhook"}, status_code=400)
+        return JSONResponse({"error": "该告警器 webhook 非法"}, status_code=400)
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    card = build_feishu_card("alert", task_row.get("name", ""), "测试",
-                             0.0, int(task_row.get("alert_threshold") or 90), ts)
+    card = build_feishu_card("alert", n.get("name", ""), "测试", 0.0, 90, ts)
     card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
     ok = await send_webhook(webhook, card)
     return {"ok": ok}

--- a/app/server.py
+++ b/app/server.py
@@ -2053,14 +2053,13 @@ async def _extract_alert_fields(body: dict, user_id: int):
 
 
 def _mask_webhook(url: str) -> str:
-    """脱敏：保留 host + 尾 4 位，其余打码。不回明文全量。"""
+    """脱敏：只回 host，不暴露 webhook token（token 即 secret）。"""
     from urllib.parse import urlparse
     if not url:
         return ""
     try:
         p = urlparse(url)
-        tail = url[-4:] if len(url) > 4 else ""
-        return f"https://{p.hostname}/***{tail}"
+        return f"https://{p.hostname}/***"
     except Exception:
         return "***"
 
@@ -2242,10 +2241,11 @@ async def create_notifier_endpoint(request: Request, user: dict = Depends(get_cu
         return JSONResponse({"error": "名称不能为空"}, status_code=400)
     if not is_allowed_webhook(webhook):
         return JSONResponse({"error": "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"}, status_code=400)
+    from sqlalchemy.exc import IntegrityError
     try:
         nid = await create_notifier(user["user_id"], name, webhook)
-    except Exception:
-        return JSONResponse({"error": "创建失败：名称可能重复"}, status_code=400)
+    except IntegrityError:
+        return JSONResponse({"error": "创建失败：名称已存在"}, status_code=400)
     return {"id": nid, "status": "created"}
 
 

--- a/docs/superpowers/plans/2026-06-05-notifier-decoupling.md
+++ b/docs/superpowers/plans/2026-06-05-notifier-decoupling.md
@@ -1,0 +1,1140 @@
+# 告警器解耦 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把内联在定时任务里的飞书告警 webhook 抽成可复用的全局「告警器（notifier）」实体，任务改为引用 `alert_notifier_id`。
+
+**Architecture:** 新增 `notifiers` 表（按 user 隔离）+ 一套 CRUD API；定时任务表新增 `alert_notifier_id` 列、停用旧 `alert_webhook` 列；调度器改为按 id 查告警器拿实时 webhook；前端两处任务表单的 webhook 输入框换成告警器下拉，新增告警器管理 UI。阈值/开关仍留任务上，触发逻辑不变。
+
+**Tech Stack:** Python + FastAPI + SQLAlchemy(async) + SQLite/PostgreSQL；前端 Vue 3 + Vite；测试 pytest(async httpx client) + vitest(build)。
+
+**设计文档：** `docs/superpowers/specs/2026-06-05-notifier-decoupling-design.md`
+
+**关键约定（全程遵守）：**
+- `alert_notifier_id INTEGER NOT NULL DEFAULT 0`，`0` = 未选告警器（主键从 1 起，0 安全作哨兵）。
+- 删除告警器：被任务引用则拒绝，返回引用数（同事务内 COUNT+DELETE，避免 TOCTOU）。
+- `GET /api/notifiers` 返回的 webhook **脱敏**（只回 host + 尾部打码）；编辑时 webhook 留空 = 不改。
+- 旧 `alert_webhook` 列物理保留、停止读写（不做 DROP COLUMN）。
+- notifier 函数在调用处 `import`（与现有 `_maybe_send_alert`/`alert_test` 一致，便于测试 monkeypatch）。
+
+**测试运行：** 后端 `python -m pytest tests/ -v`；前端 `cd frontend && bun run build`（前端用 bun）。
+
+---
+
+## Task 1: notifiers 表 + alert_notifier_id 列（schema 与迁移）
+
+**Files:**
+- Modify: `app/db.py`（`_SQLITE_SCHEMA` ~42 行、`_PG_SCHEMA` ~142 行、`init_db()` 迁移段 ~311-330 行）
+- Test: `tests/test_alert_db.py`
+
+- [ ] **Step 1: 写失败测试 —— 建表后能插入/读取告警器，且任务有 alert_notifier_id 列**
+
+在 `tests/test_alert_db.py` 末尾追加：
+
+```python
+@pytest.mark.asyncio
+async def test_notifier_table_and_task_column_exist():
+    from app.db import engine
+    from sqlalchemy import text
+    async with engine.connect() as conn:
+        # notifiers 表可插入
+        await conn.execute(text(
+            "INSERT INTO notifiers (user_id, name, type, webhook) "
+            "VALUES (1, 'n1', 'feishu', 'https://open.feishu.cn/x')"))
+        # scheduled_tasks 有 alert_notifier_id 列（默认 0）
+        cur = await conn.execute(text(
+            "SELECT alert_notifier_id FROM scheduled_tasks LIMIT 0"))
+        assert cur is not None
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_db.py::test_notifier_table_and_task_column_exist -v`
+Expected: FAIL（`no such table: notifiers` 或 `no such column`）
+
+- [ ] **Step 3: 加 notifiers 表到两套 schema**
+
+在 `_SQLITE_SCHEMA` 里（紧跟 `scheduled_tasks` 表定义之后）加：
+
+```sql
+CREATE TABLE IF NOT EXISTS notifiers (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    type       TEXT NOT NULL DEFAULT 'feishu',
+    webhook    TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(user_id, name)
+);
+```
+
+在 `_PG_SCHEMA` 里（紧跟 PG 的 `scheduled_tasks` 表定义之后）加：
+
+```sql
+CREATE TABLE IF NOT EXISTS notifiers (
+    id         SERIAL PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    type       TEXT NOT NULL DEFAULT 'feishu',
+    webhook    TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, name)
+);
+```
+
+- [ ] **Step 4: 加 alert_notifier_id 列迁移到 init_db()**
+
+在 `init_db()` 里 `scheduled_tasks 告警列：对已有表 ALTER TABLE` 那段（SQLite 与 PG 两个分支）各加一行：
+
+SQLite 分支（与现有 `alert_webhook` 等并列，包在 try/except 里）：
+```python
+"ALTER TABLE scheduled_tasks ADD COLUMN alert_notifier_id INTEGER NOT NULL DEFAULT 0",
+```
+
+PG 分支：
+```python
+"ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_notifier_id INTEGER NOT NULL DEFAULT 0",
+```
+
+> 注：新表 `CREATE TABLE IF NOT EXISTS` 由 `init_db()` 执行 schema 时自动建，无需额外迁移代码。`ON DELETE CASCADE` + 现有 `PRAGMA foreign_keys=ON`（db.py:34-38）保证删用户自动清理，`delete_user` 无需改。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `python -m pytest tests/test_alert_db.py::test_notifier_table_and_task_column_exist -v`
+Expected: PASS
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat(db): 新增 notifiers 表与 scheduled_tasks.alert_notifier_id 列 (#33)"
+```
+
+---
+
+## Task 2: db.py 告警器 CRUD 函数
+
+**Files:**
+- Modify: `app/db.py`（在 Profiles CRUD 段之后新增一段 Notifiers CRUD）
+- Test: `tests/test_alert_db.py`
+
+- [ ] **Step 1: 写失败测试 —— CRUD + 删除引用拦截**
+
+在 `tests/test_alert_db.py` 末尾追加：
+
+```python
+@pytest.mark.asyncio
+async def test_notifier_crud_and_delete_guard():
+    from app.db import (create_user, create_notifier, list_notifiers,
+                        get_notifier, update_notifier, delete_notifier,
+                        create_scheduled_task, update_scheduled_task)
+    uid = await create_user("ntf@example.com", "pw")
+    nid = await create_notifier(uid, "运维群", "https://open.feishu.cn/hook/a")
+    # list
+    items = await list_notifiers(uid)
+    assert len(items) == 1 and items[0]["name"] == "运维群"
+    # get
+    n = await get_notifier(nid)
+    assert n["webhook"] == "https://open.feishu.cn/hook/a" and n["type"] == "feishu"
+    # update
+    await update_notifier(nid, name="新名", webhook="https://open.feishu.cn/hook/b")
+    assert (await get_notifier(nid))["name"] == "新名"
+    # update 留空 webhook = 不改
+    await update_notifier(nid, webhook="")
+    assert (await get_notifier(nid))["webhook"] == "https://open.feishu.cn/hook/b"
+    # 未被引用可删
+    ok, refs = await delete_notifier(nid)
+    assert ok is True and refs == 0
+    # 被任务引用则拒绝
+    nid2 = await create_notifier(uid, "群2", "https://open.feishu.cn/hook/c")
+    sid = await create_scheduled_task(uid, "t", ["s"], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_notifier_id=nid2)
+    ok2, refs2 = await delete_notifier(nid2)
+    assert ok2 is False and refs2 == 1
+    assert await get_notifier(nid2) is not None  # 没被删
+```
+
+> 注：若 `create_user` 签名不同，按 `tests/conftest.py` 里现有用法调整。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_db.py::test_notifier_crud_and_delete_guard -v`
+Expected: FAIL（`cannot import name 'create_notifier'`）
+
+- [ ] **Step 3: 实现 CRUD 函数**
+
+在 `app/db.py` 的 Profiles CRUD 段之后新增：
+
+```python
+# ---- Notifiers CRUD ----
+
+def _row_to_notifier(row) -> dict:
+    return dict(row._mapping)
+
+
+async def create_notifier(user_id: int, name: str, webhook: str,
+                          type: str = "feishu") -> int:
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("""INSERT INTO notifiers (user_id, name, type, webhook)
+                   VALUES (:uid, :name, :type, :wh)"""),
+            {"uid": user_id, "name": name, "type": type, "wh": webhook},
+        )
+        if _is_sqlite:
+            return cur.lastrowid
+        result = await conn.execute(text("SELECT lastval()"))
+        return (result.fetchone())[0]
+
+
+async def list_notifiers(user_id: int) -> list[dict]:
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text("SELECT * FROM notifiers WHERE user_id=:uid ORDER BY id"),
+            {"uid": user_id},
+        )
+        return [_row_to_notifier(r) for r in cur.fetchall()]
+
+
+async def get_notifier(notifier_id: int) -> Optional[dict]:
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text("SELECT * FROM notifiers WHERE id=:id"), {"id": notifier_id}
+        )
+        row = cur.fetchone()
+        return _row_to_notifier(row) if row else None
+
+
+async def update_notifier(notifier_id: int, **fields):
+    async with engine.begin() as conn:
+        allowed = {"name", "webhook", "type"}
+        set_parts = []
+        values = {"id": notifier_id}
+        for k, v in fields.items():
+            if k not in allowed:
+                continue
+            if k == "webhook" and (v is None or v == ""):
+                continue  # 留空 = 不改 webhook（避免覆盖成空）
+            set_parts.append(f"{k}=:{k}")
+            values[k] = v
+        if not set_parts:
+            return
+        set_parts.append(f"updated_at={_now_sql()}")
+        await conn.execute(
+            text(f"UPDATE notifiers SET {', '.join(set_parts)} WHERE id=:id"),
+            values,
+        )
+
+
+async def delete_notifier(notifier_id: int) -> tuple[bool, int]:
+    """同事务内先查引用再删，避免 TOCTOU。返回 (是否已删, 引用任务数)。"""
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("SELECT COUNT(*) FROM scheduled_tasks WHERE alert_notifier_id=:id"),
+            {"id": notifier_id},
+        )
+        refs = (cur.fetchone())[0]
+        if refs > 0:
+            return False, refs
+        await conn.execute(
+            text("DELETE FROM notifiers WHERE id=:id"), {"id": notifier_id}
+        )
+        return True, 0
+```
+
+> 检查文件顶部已 `from typing import Optional`（现有 `get_scheduled_task` 已用，无需新增）。`_now_sql()` 为现有 helper。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `python -m pytest tests/test_alert_db.py::test_notifier_crud_and_delete_guard -v`
+Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat(db): 告警器 CRUD 函数与删除引用拦截 (#33)"
+```
+
+---
+
+## Task 3: 任务 DB 函数改用 alert_notifier_id
+
+**Files:**
+- Modify: `app/db.py`（`create_scheduled_task` ~1126、`update_scheduled_task` allowed 集合 ~1201）
+- Test: `tests/test_alert_db.py`
+
+- [ ] **Step 1: 写失败测试 —— 创建任务时带 alert_notifier_id 并能读回**
+
+在 `tests/test_alert_db.py` 末尾追加：
+
+```python
+@pytest.mark.asyncio
+async def test_create_task_with_notifier_id():
+    from app.db import create_user, create_notifier, create_scheduled_task, get_scheduled_task
+    uid = await create_user("tnid@example.com", "pw")
+    nid = await create_notifier(uid, "g", "https://open.feishu.cn/hook/z")
+    sid = await create_scheduled_task(uid, "t", ["s"], {}, "interval", "300",
+                                      alert_notifier_id=nid, alert_threshold=80,
+                                      alert_enabled=True)
+    row = await get_scheduled_task(sid)
+    assert row["alert_notifier_id"] == nid
+    assert row["alert_threshold"] == 80
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_db.py::test_create_task_with_notifier_id -v`
+Expected: FAIL（`create_scheduled_task() got an unexpected keyword argument 'alert_notifier_id'`）
+
+- [ ] **Step 3: 改 create_scheduled_task —— 去掉 alert_webhook 形参/列，加 alert_notifier_id**
+
+把 `create_scheduled_task`（db.py:1126-1144）整体替换为：
+
+```python
+async def create_scheduled_task(user_id: int, name: str, profile_ids: list,
+                                configs_json: dict, schedule_type: str,
+                                schedule_value: str, alert_notifier_id: int = 0,
+                                alert_threshold: int = 90,
+                                alert_enabled: bool = False) -> int:
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("""INSERT INTO scheduled_tasks (user_id, name, profile_ids, configs_json,
+                    schedule_type, schedule_value, alert_notifier_id, alert_threshold, alert_enabled)
+                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :ani, :at, :ae)"""),
+            {"uid": user_id, "name": name, "pids": json.dumps(profile_ids),
+             "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value,
+             "ani": alert_notifier_id, "at": alert_threshold,
+             "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled)},
+        )
+        if _is_sqlite:
+            return cur.lastrowid
+        result = await conn.execute(text("SELECT lastval()"))
+        return (result.fetchone())[0]
+```
+
+- [ ] **Step 4: 改 update_scheduled_task allowed 集合**
+
+把 `update_scheduled_task`（db.py:1201-1203）的 `allowed` 集合：去掉 `"alert_webhook"`、加 `"alert_notifier_id"`：
+
+```python
+        allowed = {"name", "profile_ids", "configs_json", "schedule_type",
+                   "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
+                   "alert_notifier_id", "alert_threshold", "alert_enabled", "alert_state"}
+```
+
+- [ ] **Step 5: 迁移依赖 alert_webhook 的既有 DB 用例**
+
+既有用例直接传 `alert_webhook=` 给 `create_scheduled_task` / `update_scheduled_task`，去掉形参后会报错，必须改：
+
+- 删除 `test_alert_fields_roundtrip`（tests/test_alert_db.py:14-24）—— 其 roundtrip 已被本 Task 的 `test_create_task_with_notifier_id` 覆盖。
+- 改 `test_update_alert_enabled_roundtrip`（tests/test_alert_db.py:28-37）：去掉 `alert_webhook="..."` 入参与 `row["alert_webhook"]` 断言，只保留 `alert_enabled` 的开关 roundtrip：
+
+```python
+@pytest.mark.asyncio
+async def test_update_alert_enabled_roundtrip():
+    sid = await create_scheduled_task(1, "t3", [], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_enabled=True)
+    assert bool((await get_scheduled_task(sid))["alert_enabled"]) is True
+    await update_scheduled_task(sid, alert_enabled=False)
+    assert bool((await get_scheduled_task(sid))["alert_enabled"]) is False
+```
+
+- [ ] **Step 6: 跑测试确认通过 + 全量告警 DB 测试不回归**
+
+Run: `python -m pytest tests/test_alert_db.py -v`
+Expected: PASS（含新用例与迁移后的既有用例）
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat(db): 定时任务改用 alert_notifier_id (#33)"
+```
+
+---
+
+## Task 4: server.py 入参校验改 notifier_id
+
+**Files:**
+- Modify: `app/server.py`（`_extract_alert_fields` ~2028、`create_schedule` ~2085-2093、`update_schedule` ~2124）
+- Test: `tests/test_alert_api.py`
+
+- [ ] **Step 1: 写失败测试 —— 任务收 alert_notifier_id 并校验归属**
+
+替换 `tests/test_alert_api.py` 中 `test_create_schedule_with_alert`（15-29 行）为基于 notifier_id 的版本，并新增归属校验：
+
+```python
+async def _make_notifier(client, headers, name="g", webhook="https://open.feishu.cn/hook/x"):
+    resp = await client.post("/api/notifiers",
+                             json={"name": name, "webhook": webhook}, headers=headers)
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_with_notifier(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid, "alert_threshold": 88,
+    }, headers=headers)
+    assert resp.status_code == 200
+    sid = resp.json()["id"]
+    row = await get_scheduled_task(sid)
+    assert row["alert_notifier_id"] == nid and row["alert_threshold"] == 88
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_foreign_notifier(client):
+    from tests.conftest import login_and_get_token
+    headers_a = await auth_headers(client)
+    nid_a = await _make_notifier(client, headers_a)
+    headers_b = await login_and_get_token(client, "b2@example.com", "pw12345678")
+    await _make_profile(client, headers_b)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid_a,
+    }, headers=headers_b)
+    assert resp.status_code == 400
+```
+
+同时删除旧的 `test_create_schedule_rejects_bad_webhook`（31-40 行，webhook 校验已移到 notifier 层，Task 5 覆盖）。
+
+> `login_and_get_token` 的参数与既有 `test_alert_test_rejects_other_user` 用法保持一致；邮箱用未注册过的。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_api.py::test_create_schedule_with_notifier tests/test_alert_api.py::test_create_schedule_rejects_foreign_notifier -v`
+Expected: FAIL（notifiers 端点不存在 / 未校验 notifier_id）
+
+> 说明：此 Task 依赖 Task 5 的 `POST /api/notifiers` 端点。建议与 Task 5 连续实现；先在本 Task 写入服务端校验逻辑，端点在 Task 5 落地后这两个测试转 PASS。
+
+- [ ] **Step 3: 改 _extract_alert_fields —— 加 user_id 参数 + notifier_id 校验，删 webhook 分支**
+
+把 `_extract_alert_fields`（server.py:2028-2047）替换为：
+
+```python
+async def _extract_alert_fields(body: dict, user_id: int):
+    """从请求体提取并校验告警字段。返回 (fields, error)。error 非空表示校验失败。"""
+    from app.db import get_notifier
+    out = {}
+    if "alert_enabled" in body:
+        out["alert_enabled"] = bool(body["alert_enabled"])
+    if "alert_threshold" in body:
+        try:
+            t = int(body["alert_threshold"])
+        except (ValueError, TypeError):
+            return None, "alert_threshold 必须是 0-100 的整数"
+        if not (0 <= t <= 100):
+            return None, "alert_threshold 必须在 0-100 之间"
+        out["alert_threshold"] = t
+    if "alert_notifier_id" in body:
+        try:
+            nid = int(body.get("alert_notifier_id") or 0)
+        except (ValueError, TypeError):
+            return None, "alert_notifier_id 非法"
+        if nid:
+            n = await get_notifier(nid)
+            if not n or n["user_id"] != user_id:
+                return None, "告警器不存在或无权使用"
+        out["alert_notifier_id"] = nid
+    return out, None
+```
+
+> 注意：函数从同步改为 `async`（因为要 `await get_notifier`）。
+
+- [ ] **Step 4: 改两处调用点**
+
+`create_schedule`（server.py:2085）改为 `await` 并传 user_id，并把 create 调用的 `alert_webhook=...` 换成 `alert_notifier_id=...`：
+
+```python
+    alert_fields, alert_err = await _extract_alert_fields(body, user_id)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+
+    sid = await create_scheduled_task(
+        user_id, name, profile_ids, configs_json, schedule_type, schedule_value,
+        alert_notifier_id=alert_fields.get("alert_notifier_id", 0),
+        alert_threshold=alert_fields.get("alert_threshold", 90),
+        alert_enabled=alert_fields.get("alert_enabled", False),
+    )
+```
+
+`update_schedule`（server.py:2124）改为 `await` 并传 user_id：
+
+```python
+    alert_fields, alert_err = await _extract_alert_fields(body, user_id)
+    if alert_err:
+        return JSONResponse({"error": alert_err}, status_code=400)
+    fields.update(alert_fields)
+```
+
+- [ ] **Step 5: 跑测试（依赖 Task 5 端点；先确认无语法/导入错误）**
+
+Run: `python -m pytest tests/test_alert_api.py -v`
+Expected: 与 notifier 端点相关的用例在 Task 5 完成后 PASS；本步先确认无 import/语法错误。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add app/server.py tests/test_alert_api.py
+git commit -m "feat(api): 任务告警入参改用 alert_notifier_id 并校验归属 (#33)"
+```
+
+---
+
+## Task 5: server.py 告警器 CRUD + test 端点
+
+**Files:**
+- Modify: `app/server.py`（在 schedules 端点附近新增 notifiers 端点；改写 alert_test）
+- Test: `tests/test_alert_api.py`
+
+- [ ] **Step 1: 写失败测试 —— notifier CRUD + 脱敏 + 删除拦截 + test 端点**
+
+替换 `tests/test_alert_api.py` 中 3 个旧 alert-test 用例（`test_alert_test_endpoint`/`test_alert_test_rejects_other_user`/`test_alert_test_requires_webhook`，51-99 行）为 notifier 级版本，并新增 CRUD/脱敏/删除拦截：
+
+```python
+@pytest.mark.asyncio
+async def test_notifier_crud_api(client):
+    headers = await auth_headers(client)
+    # 创建
+    r = await client.post("/api/notifiers",
+                          json={"name": "群A", "webhook": "https://open.feishu.cn/hook/aaa"},
+                          headers=headers)
+    assert r.status_code == 200
+    nid = r.json()["id"]
+    # 列表：webhook 脱敏（不回明文全量）
+    items = (await client.get("/api/notifiers", headers=headers)).json()
+    assert len(items) == 1
+    assert items[0]["webhook"] != "https://open.feishu.cn/hook/aaa"
+    assert "open.feishu.cn" in items[0]["webhook"]
+    # 更新
+    r2 = await client.put(f"/api/notifiers/{nid}",
+                          json={"name": "群A改"}, headers=headers)
+    assert r2.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_notifier_create_rejects_bad_webhook(client):
+    headers = await auth_headers(client)
+    r = await client.post("/api/notifiers",
+                          json={"name": "x", "webhook": "http://evil.com/h"},
+                          headers=headers)
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_notifier_delete_guard(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
+    # 任务引用它
+    await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid,
+    }, headers=headers)
+    # 删除被拦截
+    r = await client.delete(f"/api/notifiers/{nid}", headers=headers)
+    assert r.status_code == 409
+    assert "1" in str(r.json())
+
+
+@pytest.mark.asyncio
+async def test_notifier_test_endpoint(client, monkeypatch):
+    sent = {}
+    async def fake_send(url, payload, timeout=10.0):
+        sent["url"] = url
+        return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    headers = await auth_headers(client)
+    nid = await _make_notifier(client, headers)
+    r = await client.post(f"/api/notifiers/{nid}/test", headers=headers)
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert sent["url"].startswith("https://open.feishu.cn")
+
+
+@pytest.mark.asyncio
+async def test_notifier_rejects_other_user(client):
+    from tests.conftest import login_and_get_token
+    headers_a = await auth_headers(client)
+    nid = await _make_notifier(client, headers_a)
+    headers_b = await login_and_get_token(client, "b3@example.com", "pw12345678")
+    r = await client.delete(f"/api/notifiers/{nid}", headers=headers_b)
+    assert r.status_code == 404
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_api.py -k notifier -v`
+Expected: FAIL（notifiers 端点 404/不存在）
+
+- [ ] **Step 3: 实现脱敏 helper**
+
+在 `app/server.py` 合适位置（靠近 `_extract_alert_fields`）新增：
+
+```python
+def _mask_webhook(url: str) -> str:
+    """脱敏：保留 host + 路径尾 4 位，其余打码。不回明文全量。"""
+    from urllib.parse import urlparse
+    if not url:
+        return ""
+    try:
+        p = urlparse(url)
+        tail = url[-4:] if len(url) > 4 else ""
+        return f"https://{p.hostname}/***{tail}"
+    except Exception:
+        return "***"
+```
+
+- [ ] **Step 4: 实现 notifier CRUD + test 端点**
+
+在 `app/server.py` schedules 端点附近新增：
+
+```python
+@app.get("/api/notifiers")
+async def list_notifiers_endpoint(user: dict = Depends(get_current_user)):
+    from app.db import list_notifiers
+    items = await list_notifiers(user["user_id"])
+    return [
+        {"id": n["id"], "name": n["name"], "type": n["type"],
+         "webhook": _mask_webhook(n["webhook"])}
+        for n in items
+    ]
+
+
+@app.post("/api/notifiers")
+async def create_notifier_endpoint(request: Request, user: dict = Depends(get_current_user)):
+    from app.db import create_notifier
+    from app.notifier import is_allowed_webhook
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    webhook = (body.get("webhook") or "").strip()
+    if not name:
+        return JSONResponse({"error": "名称不能为空"}, status_code=400)
+    if not is_allowed_webhook(webhook):
+        return JSONResponse({"error": "webhook 必须是 https 的飞书域名 (open.feishu.cn / open.larksuite.com)"}, status_code=400)
+    try:
+        nid = await create_notifier(user["user_id"], name, webhook)
+    except Exception:
+        return JSONResponse({"error": "创建失败：名称可能重复"}, status_code=400)
+    return {"id": nid, "status": "created"}
+
+
+@app.put("/api/notifiers/{notifier_id}")
+async def update_notifier_endpoint(notifier_id: int, request: Request,
+                                   user: dict = Depends(get_current_user)):
+    from app.db import get_notifier, update_notifier
+    from app.notifier import is_allowed_webhook
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    body = await request.json()
+    fields = {}
+    if "name" in body:
+        nm = (body.get("name") or "").strip()
+        if not nm:
+            return JSONResponse({"error": "名称不能为空"}, status_code=400)
+        fields["name"] = nm
+    if "webhook" in body:
+        wh = (body.get("webhook") or "").strip()
+        if wh and not is_allowed_webhook(wh):
+            return JSONResponse({"error": "webhook 必须是 https 的飞书域名"}, status_code=400)
+        fields["webhook"] = wh  # 空串 = 不改（db 层 update_notifier 已处理）
+    await update_notifier(notifier_id, **fields)
+    return {"status": "updated"}
+
+
+@app.delete("/api/notifiers/{notifier_id}")
+async def delete_notifier_endpoint(notifier_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_notifier, delete_notifier
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    ok, refs = await delete_notifier(notifier_id)
+    if not ok:
+        return JSONResponse({"error": f"还有 {refs} 个任务在用，先解绑再删", "refs": refs}, status_code=409)
+    return {"status": "deleted"}
+
+
+@app.post("/api/notifiers/{notifier_id}/test")
+async def notifier_test(notifier_id: int, user: dict = Depends(get_current_user)):
+    from app.db import get_notifier
+    # notifier 函数内 import：保持 send_webhook 调用时解析，便于测试 monkeypatch，勿上移顶部
+    from app.notifier import build_feishu_card, send_webhook, is_allowed_webhook
+    from datetime import datetime
+    n = await get_notifier(notifier_id)
+    if not n or n["user_id"] != user["user_id"]:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    webhook = (n.get("webhook") or "").strip()
+    if not webhook or not is_allowed_webhook(webhook):
+        return JSONResponse({"error": "该告警器 webhook 非法"}, status_code=400)
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    card = build_feishu_card("alert", n.get("name", ""), "测试", 0.0, 90, ts)
+    card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
+    ok = await send_webhook(webhook, card)
+    return {"ok": ok}
+```
+
+- [ ] **Step 5: 删除旧的 alert_test 端点**
+
+删除 `app/server.py` 的 `@app.post("/api/schedules/{task_id}/alert-test")` 端点及其 `alert_test` 函数（2205-2222 行）。
+
+- [ ] **Step 6: 跑测试确认通过（含 Task 4 的两个用例）**
+
+Run: `python -m pytest tests/test_alert_api.py -v`
+Expected: PASS（全部，含 Task 4 的 `test_create_schedule_with_notifier` / `test_create_schedule_rejects_foreign_notifier`）
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add app/server.py tests/test_alert_api.py
+git commit -m "feat(api): 告警器 CRUD + 测试端点，移除任务级 alert-test (#33)"
+```
+
+---
+
+## Task 6: scheduler 改读告警器
+
+**Files:**
+- Modify: `app/scheduler.py`（`_maybe_send_alert` ~227-249）
+- Test: `tests/test_alert_scheduler.py`
+
+- [ ] **Step 1: 写失败测试 —— 引用告警器后跌破阈值能发；notifier_id=0 跳过**
+
+查看 `tests/test_alert_scheduler.py` 现有用例的构造方式（如何造 task_row、如何 monkeypatch send_webhook），在末尾追加同风格用例：
+
+```python
+@pytest.mark.asyncio
+async def test_alert_uses_notifier_webhook(monkeypatch):
+    from app import scheduler as sch
+    from app.db import create_user, create_notifier
+    sent = {}
+    async def fake_send(url, payload, timeout=10.0):
+        sent["url"] = url
+        return True
+    monkeypatch.setattr("app.notifier.send_webhook", fake_send)
+    async def fake_rate(run_ids):
+        return 0, 10  # 成功率 0%，必触发
+    monkeypatch.setattr("app.db.get_run_success_rate", fake_rate)
+
+    uid = await create_user("sch_ntf@example.com", "pw")
+    nid = await create_notifier(uid, "g", "https://open.feishu.cn/hook/sch")
+    task_row = {"alert_enabled": True, "alert_notifier_id": nid,
+                "alert_threshold": 90, "alert_state": "ok",
+                "name": "t", "profile_ids": ["s"]}
+    await sch._maybe_send_alert(1, task_row, ["r1"])
+    assert sent.get("url") == "https://open.feishu.cn/hook/sch"
+
+
+@pytest.mark.asyncio
+async def test_alert_skips_when_no_notifier(monkeypatch):
+    from app import scheduler as sch
+    called = {"n": 0}
+    async def fake_send(url, payload, timeout=10.0):
+        called["n"] += 1
+        return True
+    monkeypatch.setattr("app.notifier.send_webhook", fake_send)
+    task_row = {"alert_enabled": True, "alert_notifier_id": 0,
+                "alert_threshold": 90, "alert_state": "ok",
+                "name": "t", "profile_ids": ["s"]}
+    await sch._maybe_send_alert(1, task_row, ["r1"])
+    assert called["n"] == 0
+```
+
+> 按 `tests/test_alert_scheduler.py` 现有 monkeypatch 目标路径微调（现有用例怎么打 send_webhook 就怎么打）。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_scheduler.py::test_alert_uses_notifier_webhook tests/test_alert_scheduler.py::test_alert_skips_when_no_notifier -v`
+Expected: FAIL（仍读 alert_webhook）
+
+- [ ] **Step 3: 改 _maybe_send_alert**
+
+把 `_maybe_send_alert`（scheduler.py:227-249）替换为：
+
+```python
+async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
+    """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
+    from app.db import get_run_success_rate, get_notifier
+    # notifier 在函数内 import：保持 send_webhook 在调用时解析，便于测试 monkeypatch
+    from app.notifier import evaluate_alert, build_feishu_card, send_webhook
+
+    notifier_id = task_row.get("alert_notifier_id") or 0
+    if not task_row.get("alert_enabled") or not notifier_id:
+        return  # 未开启 或 未选告警器：不发、不报错
+    ntf = await get_notifier(notifier_id)
+    webhook = (ntf or {}).get("webhook", "").strip() if ntf else ""
+    if not webhook:
+        log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
+        return
+    success, total = await get_run_success_rate(run_ids)
+    if total == 0:
+        log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
+        return
+    rate = success / total * 100
+    threshold = int(task_row.get("alert_threshold") or 90)
+    prev = task_row.get("alert_state") or "ok"
+    new_state, action = evaluate_alert(prev, rate, threshold)
+    if action:
+        profiles_text = ", ".join(task_row.get("profile_ids", []) or []) or "-"
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        card = build_feishu_card(action, task_row.get("name", ""), profiles_text, rate, threshold, ts)
+        await send_webhook(webhook, card)
+    if new_state != prev:
+        await update_scheduled_task(task_id, alert_state=new_state)
+```
+
+- [ ] **Step 4: 迁移既有调度告警用例的 `_seed` helper**
+
+`tests/test_alert_scheduler.py` 的 `_seed`（8-22 行）给 `create_scheduled_task` 传了 `alert_webhook=`，且所有调度告警用例都经它造 task_row。改 `_seed`：先建 notifier，把 `alert_webhook=...` 换成 `alert_notifier_id=`：
+
+```python
+async def _seed(rate_pair, alert_state="ok", enabled=True):
+    from app.db import create_notifier
+    succ, tot = rate_pair
+    nid = await create_notifier(1, "g", "https://open.feishu.cn/x")
+    sid = await create_scheduled_task(
+        1, "t", ["SiteA"], {}, "interval", "300",
+        alert_notifier_id=nid, alert_threshold=90, alert_enabled=enabled,
+    )
+    if alert_state != "ok":
+        await update_scheduled_task(sid, alert_state=alert_state)
+    await save_result(
+        user_id=1, test_id="a", filename="a.json", timestamp="20260604_120000",
+        config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+        percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
+    )
+    return sid
+```
+
+> 这样 `_maybe_send_alert` 经 `get_notifier(nid)` 拿到 `https://open.feishu.cn/x`，既有的 fire/recover/disabled/no-results 用例逻辑不变。`test_no_alert_when_disabled` 用 `enabled=False` 仍走「未开启即跳过」分支，通过。
+
+- [ ] **Step 5: 跑测试确认通过 + 既有调度告警测试不回归**
+
+Run: `python -m pytest tests/test_alert_scheduler.py -v`
+Expected: PASS（含新用例与迁移后的既有用例）
+
+- [ ] **Step 6: 全量后端测试**
+
+Run: `python -m pytest tests/ -v`
+Expected: PASS（全绿）
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add app/scheduler.py tests/test_alert_scheduler.py
+git commit -m "feat(scheduler): 告警按 notifier_id 查实时 webhook (#33)"
+```
+
+---
+
+## Task 7: 前端 API 客户端
+
+**Files:**
+- Modify: `frontend/src/api/index.js`（~47-61 Schedules 段）
+
+- [ ] **Step 1: 新增 notifier API + 改 alertTestApi**
+
+在 `frontend/src/api/index.js` 的 Schedules 段附近新增，并把 `alertTestApi`（61 行）改为 notifier 级：
+
+```javascript
+// Notifiers
+export const getNotifiers = () => api('/api/notifiers');
+export const createNotifierApi = (data) => api('/api/notifiers', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+export const updateNotifierApi = (id, data) => api(`/api/notifiers/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+export const deleteNotifierApi = (id) => api(`/api/notifiers/${id}`, { method: 'DELETE' });
+export const notifierTestApi = (id) => api(`/api/notifiers/${id}/test`, { method: 'POST' });
+```
+
+删除旧的 `alertTestApi`（61 行）。
+
+- [ ] **Step 2: 构建确认无引用错误**
+
+Run: `cd frontend && bun run build`
+Expected: 构建报错指出 `alertTestApi` 仍被 `SiteSchedulesTab.vue` 引用 —— 这是预期的，Task 9 修复。可先跳过验证，待 Task 9 后统一 build。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add frontend/src/api/index.js
+git commit -m "feat(web): 告警器 API 客户端，alert-test 迁移到 notifier 级 (#33)"
+```
+
+---
+
+## Task 8: 告警器管理 UI
+
+**Files:**
+- Create: `frontend/src/components/NotifiersManager.vue`
+- Modify: `frontend/src/views/SettingsView.vue`（挂载新组件）
+
+- [ ] **Step 1: 看 SettingsView 结构，确定挂载点**
+
+Read: `frontend/src/views/SettingsView.vue` —— 确认其分区/卡片写法，把告警器管理作为一个新卡片/分区挂进去（沿用页面现有样式 class）。
+
+- [ ] **Step 2: 新建 NotifiersManager.vue**
+
+```vue
+<template>
+  <div class="notifiers-manager">
+    <div class="nm-header">
+      <h3>告警器</h3>
+      <button class="btn btn-primary" @click="openCreate">新建告警器</button>
+    </div>
+    <div v-if="items.length === 0" class="form-hint">还没有告警器，点「新建」添加一个飞书机器人。</div>
+    <ul class="nm-list">
+      <li v-for="n in items" :key="n.id" class="nm-item">
+        <div class="nm-meta">
+          <span class="nm-name">{{ n.name }}</span>
+          <span class="nm-type">{{ n.type }}</span>
+          <span class="nm-webhook">{{ n.webhook }}</span>
+        </div>
+        <div class="nm-actions">
+          <button class="btn btn-ghost" :disabled="testingId === n.id" @click="onTest(n)">{{ testingId === n.id ? '发送中...' : '测试' }}</button>
+          <button class="btn btn-ghost" @click="openEdit(n)">编辑</button>
+          <button class="btn btn-ghost" @click="onDelete(n)">删除</button>
+        </div>
+      </li>
+    </ul>
+
+    <div v-if="showForm" class="nm-form">
+      <div class="form-group">
+        <label class="form-label">名称</label>
+        <input class="form-input" v-model.trim="form.name" placeholder="运维群飞书">
+      </div>
+      <div class="form-group">
+        <label class="form-label">飞书 Webhook URL</label>
+        <input class="form-input" v-model.trim="form.webhook" :placeholder="editingId ? '留空 = 不修改' : 'https://open.feishu.cn/open-apis/bot/v2/hook/...'">
+      </div>
+      <div class="btn-group">
+        <button class="btn btn-primary" :disabled="saving" @click="onSave">保存</button>
+        <button class="btn btn-ghost" @click="closeForm">取消</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { getNotifiers, createNotifierApi, updateNotifierApi, deleteNotifierApi, notifierTestApi } from '../api/index.js';
+import { toast } from '../composables/useToast.js';
+
+const items = ref([]);
+const showForm = ref(false);
+const editingId = ref(null);
+const saving = ref(false);
+const testingId = ref(null);
+const form = ref({ name: '', webhook: '' });
+
+async function load() {
+  try { items.value = await getNotifiers(); } catch (e) { toast.error('加载告警器失败'); }
+}
+function openCreate() { editingId.value = null; form.value = { name: '', webhook: '' }; showForm.value = true; }
+function openEdit(n) { editingId.value = n.id; form.value = { name: n.name, webhook: '' }; showForm.value = true; }
+function closeForm() { showForm.value = false; }
+
+async function onSave() {
+  if (!form.value.name) { toast.error('名称不能为空'); return; }
+  saving.value = true;
+  try {
+    if (editingId.value) {
+      await updateNotifierApi(editingId.value, { name: form.value.name, webhook: form.value.webhook });
+    } else {
+      await createNotifierApi({ name: form.value.name, webhook: form.value.webhook });
+    }
+    showForm.value = false;
+    await load();
+    toast.success('已保存');
+  } catch (e) { toast.error(e?.message || '保存失败'); }
+  finally { saving.value = false; }
+}
+
+async function onTest(n) {
+  testingId.value = n.id;
+  try { const r = await notifierTestApi(n.id); toast[r.ok ? 'success' : 'error'](r.ok ? '测试消息已发送' : '发送失败'); }
+  catch (e) { toast.error('发送失败'); }
+  finally { testingId.value = null; }
+}
+
+async function onDelete(n) {
+  if (!confirm(`删除告警器「${n.name}」？`)) return;
+  try { await deleteNotifierApi(n.id); await load(); toast.success('已删除'); }
+  catch (e) { toast.error(e?.message || '删除失败'); }
+}
+
+onMounted(load);
+defineExpose({ load });
+</script>
+```
+
+> `toast` 用法与 `SiteSchedulesTab.vue` 一致（`import { toast } from '../composables/useToast.js'`）。若 `api()` 抛错不带 message，则 toast 文案用兜底字符串即可。
+
+- [ ] **Step 3: 挂载进 SettingsView**
+
+在 `frontend/src/views/SettingsView.vue` 合适分区引入并渲染：
+
+```javascript
+import NotifiersManager from '../components/NotifiersManager.vue';
+```
+```html
+<NotifiersManager />
+```
+
+- [ ] **Step 4: 构建验证**
+
+Run: `cd frontend && bun run build`
+Expected: 与 Task 9 一起完成后整体 PASS（此时 SiteSchedulesTab 仍引用旧 alertTestApi 会报错，留待 Task 9）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add frontend/src/components/NotifiersManager.vue frontend/src/views/SettingsView.vue
+git commit -m "feat(web): 告警器管理页 (#33)"
+```
+
+---
+
+## Task 9: SiteSchedulesTab 表单改下拉
+
+**Files:**
+- Modify: `frontend/src/components/SiteSchedulesTab.vue`（创建区 ~100-112、编辑区 ~296-312、script 387/427/504/608/655、onTestAlert 671、import 335）
+
+- [ ] **Step 1: 创建区 webhook 输入 → 告警器下拉**
+
+把创建区（~100-112）的 `<template v-if="createForm.alert_enabled">` 内的「飞书 Webhook URL」`form-group` 替换为：
+
+```html
+            <div class="form-group full">
+              <label class="form-label">告警器</label>
+              <select class="form-input" v-model.number="createForm.alert_notifier_id">
+                <option :value="0">未选择</option>
+                <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
+              </select>
+              <div class="form-hint">在「设置」页管理告警器</div>
+            </div>
+```
+
+- [ ] **Step 2: 编辑区同样替换 + 删测试按钮**
+
+把编辑区（~296-312）的「飞书 Webhook URL」`form-group` 替换为同样的下拉（`v-model.number="editForm.alert_notifier_id"`），并删除「发送测试消息」按钮那个 `form-group`（308-311 行，含 `onTestAlert`）。
+
+- [ ] **Step 3: 改 script —— 字段、加载告警器列表、删 onTestAlert**
+
+- 把 `alert_webhook: ''`（387/427 行的表单初始化）改为 `alert_notifier_id: 0`。
+- 504 行 `alert_webhook: s.alert_webhook || ''` 改为 `alert_notifier_id: s.alert_notifier_id || 0`。
+- 608/655 行提交 payload 里 `alert_webhook: f.alert_webhook || ''` 改为 `alert_notifier_id: f.alert_notifier_id || 0`。
+- import（327-336）去掉 `alertTestApi`，加 `getNotifiers`。
+- 删除 `alertTestLoading`（353）与 `onTestAlert`（671 起）。
+- 新增告警器列表加载：
+
+```javascript
+const notifiers = ref([]);
+async function loadNotifiers() {
+  try { notifiers.value = await getNotifiers(); } catch { notifiers.value = []; }
+}
+```
+在现有 `onMounted` 里调用 `loadNotifiers()`（与现有加载并列）。
+
+- [ ] **Step 4: 构建验证（含 Task 7/8）**
+
+Run: `cd frontend && bun run build`
+Expected: PASS（无 `alertTestApi` 残留引用）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add frontend/src/components/SiteSchedulesTab.vue
+git commit -m "feat(web): 任务表单(SiteSchedulesTab)告警器下拉 (#33)"
+```
+
+---
+
+## Task 10: TasksView 表单改下拉
+
+**Files:**
+- Modify: `frontend/src/views/TasksView.vue`（告警区 ~236-247、import 263、createForm 315/324、submit 511-513）
+
+- [ ] **Step 1: webhook 输入 → 告警器下拉**
+
+把告警区（~236-247）`v-if="createForm.alert_enabled"` 内的「飞书 Webhook URL」`form-group` 替换为：
+
+```html
+            <div class="form-group">
+              <label class="form-label">告警器</label>
+              <select class="form-input" v-model.number="createForm.alert_notifier_id" style="width:280px">
+                <option :value="0">未选择</option>
+                <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
+              </select>
+              <div class="form-hint">在「设置」页管理告警器</div>
+            </div>
+```
+
+- [ ] **Step 2: 改 script**
+
+- import（263）加 `getNotifiers`。
+- createForm 两处（315 reset、324 ref 初始化）把 `alert_webhook: ''` 改为 `alert_notifier_id: 0`。
+- submit payload（512）`alert_webhook: f.alert_webhook || ''` 改为 `alert_notifier_id: f.alert_notifier_id || 0`。
+- 新增并在 `onMounted` 调用：
+
+```javascript
+const notifiers = ref([]);
+async function loadNotifiers() {
+  try { notifiers.value = await getNotifiers(); } catch { notifiers.value = []; }
+}
+```
+
+- [ ] **Step 3: 构建验证**
+
+Run: `cd frontend && bun run build`
+Expected: PASS
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add frontend/src/views/TasksView.vue
+git commit -m "feat(web): 任务表单(TasksView)告警器下拉 (#33)"
+```
+
+---
+
+## Task 11: 全量验证 + 收尾
+
+- [ ] **Step 1: 后端全量测试**
+
+Run: `python -m pytest tests/ -v`
+Expected: PASS（全绿）
+
+- [ ] **Step 2: 前端构建**
+
+Run: `cd frontend && bun run build`
+Expected: PASS
+
+- [ ] **Step 3: grep 残留检查**
+
+Run: `grep -rn "alert_webhook\|alertTestApi\|alert-test" app/ frontend/src/`
+Expected: 仅 `app/db.py` 里物理保留的 `alert_webhook` 列定义（schema 字符串）可残留；应用代码、前端、API 客户端均无引用。若有其他残留，回到对应 Task 清理。
+
+- [ ] **Step 4: 推分支 + 开 PR**
+
+```bash
+git push -u origin worktree-feat+issue-33-notifier-decoupling
+gh pr create --title "重构：飞书告警解耦为可复用「告警器」(#33)" --body "Closes #33"
+```
+
+---
+
+## 自检覆盖对照（spec → task）
+
+- notifiers 表 / alert_notifier_id 列 → Task 1
+- 告警器 CRUD + 删除引用拦截（同事务） → Task 2、Task 5
+- 任务 DB 改 notifier_id → Task 3
+- `_extract_alert_fields` 加 user_id + 归属校验 → Task 4
+- notifier CRUD/test 端点 + webhook 脱敏 + 移除任务级 alert-test → Task 5
+- scheduler 查实时 webhook + notifier_id=0 安全跳过 → Task 6
+- api/index.js + 告警器管理页 → Task 7、Task 8
+- 两处任务表单（SiteSchedulesTab + TasksView）改下拉 → Task 9、Task 10
+- 测试重写（旧 alert-test 用例迁移）→ Task 4、Task 5
+- 不迁移老数据 / 旧列物理保留 → 全程不触碰 alert_webhook 列数据

--- a/docs/superpowers/specs/2026-06-05-notifier-decoupling-design.md
+++ b/docs/superpowers/specs/2026-06-05-notifier-decoupling-design.md
@@ -1,0 +1,160 @@
+# 告警器解耦设计（飞书告警重构）
+
+日期：2026-06-05
+
+## 背景与问题
+
+当前飞书告警（PR #30/#32）把告警配置直接内联在每个定时任务（`scheduled_tasks`）这一行里：
+`alert_webhook`、`alert_threshold`、`alert_enabled`、`alert_state` 四列。一个任务写死一个
+webhook。这导致"通知发到哪"和"任务本身的配置"耦合在一起——同一个飞书群要在多个任务里重复
+填 webhook，改群机器人地址要逐个任务改。
+
+## 目标
+
+把"通知配置"抽成一个可复用的全局实体——**告警器（notifier）**。创建/编辑定时任务时，从下拉里
+**选**一个已有告警器，而不是填 webhook。这样"发到哪"（告警器，可复用）和"啥时候发"（开关 +
+阈值，任务自己的）彻底分开。
+
+## 决策（已与用户对齐）
+
+1. **挂载层级**：告警器选择挂在**定时任务**上（不是站点 profile）。触发逻辑仍是任务级整体
+   成功率，与现状一致，改动最小。
+2. **阈值归属**：阈值（`alert_threshold`）**留在任务上**。告警器只管 webhook（"发到哪"），
+   不带默认阈值。
+3. **数据迁移**：**不迁移**老的内联 webhook。功能刚上线、生产几乎无真实配置，直接弃用老字段，
+   用户重新建告警器并在任务里选。
+4. **删除策略**：告警器**被任务引用时拦截删除**，返回还有几个任务在用，提示用户先解绑再删。
+5. **作用域**：告警器按 `user_id` 隔离，与站点、定时任务一致。
+
+## 数据模型
+
+### 新增表 `notifiers`
+
+每个用户管自己的告警器。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | PK（SQLite AUTOINCREMENT / PG SERIAL） | 主键 |
+| `user_id` | INTEGER NOT NULL，外键 → `users(id)` ON DELETE CASCADE | 属于谁 |
+| `name` | TEXT NOT NULL | 告警器名字（下拉显示），如"运维群飞书" |
+| `type` | TEXT NOT NULL DEFAULT 'feishu' | 类型，当前固定 feishu，留字段供未来扩展 |
+| `webhook` | TEXT NOT NULL DEFAULT '' | 飞书 webhook URL |
+| `created_at` | 时间戳 | 创建时间 |
+| `updated_at` | 时间戳 | 更新时间 |
+
+约束：`UNIQUE(user_id, name)`（同一用户下告警器名字唯一，便于识别）。
+
+建表落点：`notifiers` 表要同时加进 `app/db.py` 的 `_SQLITE_SCHEMA`（~42 行）和 `_PG_SCHEMA`
+（~142 行）两份字符串（`CREATE TABLE IF NOT EXISTS`，`init_db()` 自动建表，无需额外迁移代码）。
+`user_id ... ON DELETE CASCADE` + SQLite 的 `PRAGMA foreign_keys=ON`（db.py:34-38）已保证删用户
+时自动清理 notifiers，`delete_user`（db.py:491）无需手动加 DELETE。
+
+### 修改表 `scheduled_tasks`
+
+- ➕ 新增列 `alert_notifier_id INTEGER NOT NULL DEFAULT 0`（0 = 未选告警器；指向
+  `notifiers.id`）。0 作哨兵安全：SQLite AUTOINCREMENT / PG SERIAL 主键都从 1 起，不会发 0，
+  与现有 `scheduled_task_id INTEGER DEFAULT 0` 同构。
+  - 走现有迁移机制：`init_db()` 里把 ALTER 加进**两个列表**——SQLite 段（db.py:~313，逐列
+    try/except）`ALTER TABLE scheduled_tasks ADD COLUMN alert_notifier_id INTEGER NOT NULL DEFAULT 0`；
+    PG 段（db.py:~324）`... ADD COLUMN IF NOT EXISTS ...`。
+  - 不做物理外键约束（与现有列风格一致，应用层校验归属），便于跨 SQLite/PG。
+- ✅ 保留 `alert_threshold`、`alert_enabled`、`alert_state`（任务自己的触发规则与运行状态）。
+- ⚠️ `alert_webhook` 列**物理保留但停用**（不读不写）。理由：SQLite DROP COLUMN 脆弱，且无需
+  迁移老数据；留着不影响逻辑，后续可在独立清理中移除。
+
+## 后端改动
+
+### API（与 profiles 风格一致，挂在 `app/server.py`）
+
+| 接口 | 作用 |
+|------|------|
+| `GET /api/notifiers` | 列出当前用户的告警器（任务表单下拉用） |
+| `POST /api/notifiers` | 新建：校验 `name` 非空、`webhook` 走 `is_allowed_webhook` |
+| `PUT /api/notifiers/{id}` | 改名/换 webhook（校验归属当前用户 + SSRF 校验） |
+| `DELETE /api/notifiers/{id}` | 删除；**被任务引用则拒绝**（409/错误信息含引用数），否则删除 |
+| `POST /api/notifiers/{id}/test` | 发飞书测试消息（从原任务级 `alert-test` 迁移到告警器级） |
+
+GET/list 返回的 webhook 做**脱敏**（只回 host 或尾部打码，复用 `notifier.py:_safe_host` 思路），
+不把完整 webhook 明文回前端列表。
+
+任务创建/更新接口（`create_schedule`:2085 / `update_schedule`:2124）：
+- 入参把 `alert_webhook` 换成 `alert_notifier_id`。
+- 入参收口函数是 `_extract_alert_fields(body)`（server.py:2028，被两处共用），**不是**
+  `_sanitize_alert_config`。改造：
+  - 删掉 2042-2046 对 `alert_webhook` 走 `is_allowed_webhook` 的校验分支；
+  - 新增 `alert_notifier_id` 分支：`int` 化 + 校验「为 0，或存在且归属当前用户」。
+  - 归属校验需要 user_id，故**签名改为 `_extract_alert_fields(body, user_id)`**，两处调用点
+    同步传入。
+  - `alert_threshold`（0-100）、`alert_enabled`（布尔）校验照旧。
+
+### DB 层（`app/db.py`）
+
+- 新增告警器 CRUD 函数：`create_notifier` / `list_notifiers` / `get_notifier` /
+  `update_notifier` / `delete_notifier`。
+- `delete_notifier`：**在同一事务内**（`engine.begin()`）先 `SELECT COUNT(*) FROM
+  scheduled_tasks WHERE alert_notifier_id = ?` 再决定删/不删，规避 check-then-delete 的
+  TOCTOU 竞态；有引用则返回引用数、不删。
+- `create_scheduled_task`（db.py:1126）：删掉 `alert_webhook` 形参与 INSERT 列（让该列走
+  DEFAULT ''），改为接收并写入 `alert_notifier_id`。
+- `update_scheduled_task`（db.py:1201-1203）：`allowed` 字段集合去掉 `alert_webhook`、加
+  `alert_notifier_id`。
+
+### 调度逻辑（`app/scheduler.py` 的 `_maybe_send_alert`）
+
+- 现有判空 `not (task_row.get("alert_webhook") or "").strip()`（scheduler.py:233）改为：
+  `alert_notifier_id` 为 0 / falsy 就直接 return（**开关开着但没选告警器 = 不发、不报错**）。
+- 否则用 `task_row["alert_notifier_id"]` 查 `get_notifier(...)` 拿实时 `webhook`（注意取的是
+  实时值而非任务启动时的快照，webhook 改了会用新值，这是期望行为）。
+- 查不到（告警器已被删——删除虽被拦截，仍兜底）：跳过告警、不报错，与现有 best-effort 一致。
+  被删后引用方任务的 `alert_notifier_id` 不回填、不清零，仅运行时跳过。
+- `evaluate_alert` / `build_feishu_card` / `send_webhook` 逻辑不变。
+
+## 前端改动
+
+### 新增"告警器管理"页
+
+放在全局设置区，与站点管理平级。功能：
+- 列表展示用户的告警器（名字、类型、webhook 脱敏显示）。
+- 新建 / 编辑表单（名字 + webhook）。
+- "发送测试消息"按钮 → `POST /api/notifiers/{id}/test`。
+- 删除按钮；被引用时后端拒绝，前端提示"还有 N 个任务在用，先解绑再删"。
+
+### 改任务表单（**两处都要改**）
+
+前端有两套独立的任务告警表单，都填 `alert_webhook`，**必须一起改**，否则漏改的页面会静默
+失效（前端发废弃字段、后端忽略、用户以为配了告警）：
+
+1. `frontend/src/components/SiteSchedulesTab.vue`：创建（~105）+ 编辑（~299）两处 webhook 输入框。
+2. `frontend/src/views/TasksView.vue`：`/tasks` 活跃路由的创建表单 webhook 输入框（~239），及
+   `createForm` 初始化里的 `alert_webhook`（315/324/512）。
+
+改造内容（两处一致）：
+- 把填 webhook 的输入框换成**告警器下拉选择**（选项来自 `GET /api/notifiers`），旁边放"管理
+  告警器"链接；表单字段 `alert_webhook` → `alert_notifier_id`。
+- 阈值输入框、启用开关保持不变。
+- 原"发送测试消息"按钮从任务表单移除（测试改在告警器管理页做）。
+
+### API 客户端（`frontend/src/api/index.js`）
+
+- `alertTestApi`（index.js:61）原打 `/api/schedules/${id}/alert-test`，改为打
+  `/api/notifiers/${id}/test`（参数语义从 task id 变 notifier id），由告警器管理页调用。
+- 新增 notifier CRUD 的 API 封装。
+
+## 测试
+
+在现有 `tests/test_alert_db.py` / `test_alert_api.py` / `test_alert_scheduler.py` 上改：
+- **DB**：告警器 CRUD；删除被引用时拒绝（同事务）；任务存取 `alert_notifier_id`。
+- **API**：告警器增删改查鉴权（跨用户不可见/不可改）；SSRF 校验拒非飞书域名；删除拦截返回
+  引用数；任务创建/更新收 `alert_notifier_id` 并校验归属；list 返回 webhook 已脱敏。
+- **Scheduler**：任务引用告警器后，成功率跌破阈值能查到 webhook 并触发飞书发送；开关开着但
+  `notifier_id=0` 安全跳过；告警器缺失时安全跳过。
+- **需重写（非沿用）**：`test_alert_api.py:51-99` 的 3 个测试（`test_alert_test_endpoint` /
+  `test_alert_test_rejects_other_user` / `test_alert_test_requires_webhook`）打的是已删除的任务级
+  `/api/schedules/{id}/alert-test` 端点，需迁移改写到 notifier 级 `/api/notifiers/{id}/test`。
+
+## 不做（YAGNI）
+
+- 不做单站点级告警（仍是任务级整体成功率）。
+- 不做钉钉/企微等其他渠道（仅留 `type` 字段占位）。
+- 不迁移老 webhook 数据，不物理删除 `alert_webhook` 列。
+- 告警器不带默认阈值。

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -58,7 +58,13 @@ export const getScheduleResults = (id, { limit = 100, offset = 0, hours } = {}) 
   return api(`/api/schedules/${id}/results?${params}`);
 };
 export const getScheduleTrend = (id, { hours } = {}) => api(`/api/schedules/${id}/trend` + (hours ? `?hours=${hours}` : ''));
-export const alertTestApi = (id) => api(`/api/schedules/${id}/alert-test`, { method: 'POST' });
+
+// Notifiers
+export const getNotifiers = () => api('/api/notifiers');
+export const createNotifierApi = (data) => api('/api/notifiers', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+export const updateNotifierApi = (id, data) => api(`/api/notifiers/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+export const deleteNotifierApi = (id) => api(`/api/notifiers/${id}`, { method: 'DELETE' });
+export const notifierTestApi = (id) => api(`/api/notifiers/${id}/test`, { method: 'POST' });
 
 // Sites
 export const getSiteTrend = (profileName, { hours } = {}) => {

--- a/frontend/src/components/NotifiersManager.vue
+++ b/frontend/src/components/NotifiersManager.vue
@@ -15,7 +15,13 @@
         <div class="nm-actions">
           <button class="btn btn-ghost" :disabled="testingId === n.id" @click="onTest(n)">{{ testingId === n.id ? '发送中...' : '测试' }}</button>
           <button class="btn btn-ghost" @click="openEdit(n)">编辑</button>
-          <button class="btn btn-ghost" @click="onDelete(n)">删除</button>
+          <InlineConfirmDelete
+            :active="deleteCandidate === n.id"
+            title="删除告警器"
+            @request.stop="deleteCandidate = n.id"
+            @cancel.stop="deleteCandidate = null"
+            @confirm.stop="onDelete(n)"
+          >删除</InlineConfirmDelete>
         </div>
       </li>
     </ul>
@@ -41,12 +47,14 @@
 import { ref, onMounted } from 'vue';
 import { getNotifiers, createNotifierApi, updateNotifierApi, deleteNotifierApi, notifierTestApi } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
+import InlineConfirmDelete from './InlineConfirmDelete.vue';
 
 const items = ref([]);
 const showForm = ref(false);
 const editingId = ref(null);
 const saving = ref(false);
 const testingId = ref(null);
+const deleteCandidate = ref(null);
 const form = ref({ name: '', webhook: '' });
 
 async function load() {
@@ -80,13 +88,13 @@ async function onTest(n) {
 }
 
 async function onDelete(n) {
-  if (!confirm(`删除告警器「${n.name}」？`)) return;
   try {
     const res = await deleteNotifierApi(n.id);
     if (res && res.error) { toast(res.error, 'error'); return; }
     await load();
     toast('已删除', 'success');
   } catch (e) { toast(e?.message || '删除失败', 'error'); }
+  finally { deleteCandidate.value = null; }
 }
 
 onMounted(load);

--- a/frontend/src/components/NotifiersManager.vue
+++ b/frontend/src/components/NotifiersManager.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="notifiers-manager">
+    <div class="nm-header">
+      <h3>告警器</h3>
+      <button class="btn btn-primary" @click="openCreate">新建告警器</button>
+    </div>
+    <div v-if="items.length === 0" class="form-hint">还没有告警器，点「新建」添加一个飞书机器人。</div>
+    <ul class="nm-list">
+      <li v-for="n in items" :key="n.id" class="nm-item">
+        <div class="nm-meta">
+          <span class="nm-name">{{ n.name }}</span>
+          <span class="nm-type">{{ n.type }}</span>
+          <span class="nm-webhook">{{ n.webhook }}</span>
+        </div>
+        <div class="nm-actions">
+          <button class="btn btn-ghost" :disabled="testingId === n.id" @click="onTest(n)">{{ testingId === n.id ? '发送中...' : '测试' }}</button>
+          <button class="btn btn-ghost" @click="openEdit(n)">编辑</button>
+          <button class="btn btn-ghost" @click="onDelete(n)">删除</button>
+        </div>
+      </li>
+    </ul>
+
+    <div v-if="showForm" class="nm-form">
+      <div class="form-group">
+        <label class="form-label">名称</label>
+        <input class="form-input" v-model.trim="form.name" placeholder="运维群飞书">
+      </div>
+      <div class="form-group">
+        <label class="form-label">飞书 Webhook URL</label>
+        <input class="form-input" v-model.trim="form.webhook" :placeholder="editingId ? '留空 = 不修改' : 'https://open.feishu.cn/open-apis/bot/v2/hook/...'">
+      </div>
+      <div class="btn-group">
+        <button class="btn btn-primary" :disabled="saving" @click="onSave">保存</button>
+        <button class="btn btn-ghost" @click="closeForm">取消</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { getNotifiers, createNotifierApi, updateNotifierApi, deleteNotifierApi, notifierTestApi } from '../api/index.js';
+import { toast } from '../composables/useToast.js';
+
+const items = ref([]);
+const showForm = ref(false);
+const editingId = ref(null);
+const saving = ref(false);
+const testingId = ref(null);
+const form = ref({ name: '', webhook: '' });
+
+async function load() {
+  try { items.value = await getNotifiers(); } catch (e) { toast('加载告警器失败', 'error'); }
+}
+function openCreate() { editingId.value = null; form.value = { name: '', webhook: '' }; showForm.value = true; }
+function openEdit(n) { editingId.value = n.id; form.value = { name: n.name, webhook: '' }; showForm.value = true; }
+function closeForm() { showForm.value = false; }
+
+async function onSave() {
+  if (!form.value.name) { toast('名称不能为空', 'error'); return; }
+  saving.value = true;
+  try {
+    const res = editingId.value
+      ? await updateNotifierApi(editingId.value, { name: form.value.name, webhook: form.value.webhook })
+      : await createNotifierApi({ name: form.value.name, webhook: form.value.webhook });
+    if (res && res.error) { toast(res.error, 'error'); return; }
+    showForm.value = false;
+    await load();
+    toast('已保存', 'success');
+  } catch (e) { toast(e?.message || '保存失败', 'error'); }
+  finally { saving.value = false; }
+}
+
+async function onTest(n) {
+  testingId.value = n.id;
+  try { const r = await notifierTestApi(n.id); toast(r.ok ? '测试消息已发送' : '发送失败', r.ok ? 'success' : 'error'); }
+  catch (e) { toast('发送失败', 'error'); }
+  finally { testingId.value = null; }
+}
+
+async function onDelete(n) {
+  if (!confirm(`删除告警器「${n.name}」？`)) return;
+  try {
+    const res = await deleteNotifierApi(n.id);
+    if (res && res.error) { toast(res.error, 'error'); return; }
+    await load();
+    toast('已删除', 'success');
+  } catch (e) { toast(e?.message || '删除失败', 'error'); }
+}
+
+onMounted(load);
+defineExpose({ load });
+</script>
+
+<style scoped>
+.nm-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+.nm-header h3 { margin: 0; font-size: 16px; }
+.nm-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.nm-item { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px; }
+.nm-meta { display: flex; align-items: center; gap: 12px; min-width: 0; flex-wrap: wrap; }
+.nm-name { font-weight: 600; }
+.nm-type { font-size: 12px; opacity: 0.6; }
+.nm-webhook { font-size: 12px; opacity: 0.7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nm-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.nm-form { margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border, #e5e7eb); max-width: 500px; display: flex; flex-direction: column; gap: 12px; }
+</style>

--- a/frontend/src/components/NotifiersManager.vue
+++ b/frontend/src/components/NotifiersManager.vue
@@ -58,6 +58,7 @@ function closeForm() { showForm.value = false; }
 
 async function onSave() {
   if (!form.value.name) { toast('名称不能为空', 'error'); return; }
+  if (!editingId.value && !form.value.webhook) { toast('Webhook 不能为空', 'error'); return; }
   saving.value = true;
   try {
     const res = editingId.value
@@ -73,7 +74,7 @@ async function onSave() {
 
 async function onTest(n) {
   testingId.value = n.id;
-  try { const r = await notifierTestApi(n.id); toast(r.ok ? '测试消息已发送' : '发送失败', r.ok ? 'success' : 'error'); }
+  try { const r = await notifierTestApi(n.id); toast(r.ok ? '测试消息已发送' : (r.error || '发送失败'), r.ok ? 'success' : 'error'); }
   catch (e) { toast('发送失败', 'error'); }
   finally { testingId.value = null; }
 }

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -101,8 +101,12 @@
           </div>
           <template v-if="createForm.alert_enabled">
             <div class="form-group full">
-              <label class="form-label">飞书 Webhook URL</label>
-              <input class="form-input" v-model.trim="createForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+              <label class="form-label">告警器</label>
+              <select class="form-input" v-model.number="createForm.alert_notifier_id">
+                <option :value="0">未选择</option>
+                <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
+              </select>
+              <div class="form-hint">在「设置」页管理告警器</div>
             </div>
             <div class="form-group">
               <label class="form-label">成功率阈值（%）</label>
@@ -295,19 +299,17 @@
         </div>
         <template v-if="editForm.alert_enabled">
           <div class="form-group full">
-            <label class="form-label">飞书 Webhook URL</label>
-            <input class="form-input" v-model.trim="editForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+            <label class="form-label">告警器</label>
+            <select class="form-input" v-model.number="editForm.alert_notifier_id">
+              <option :value="0">未选择</option>
+              <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
+            </select>
+            <div class="form-hint">在「设置」页管理告警器</div>
           </div>
           <div class="form-group">
             <label class="form-label">成功率阈值（%）</label>
             <input class="form-input" type="number" v-model.number="editForm.alert_threshold" min="0" max="100" placeholder="90">
             <div class="form-hint">上次运行成功率低于该值时触发告警</div>
-          </div>
-          <div class="form-group">
-            <label class="form-label">&nbsp;</label>
-            <button type="button" class="btn btn-ghost" :disabled="!editForm.alert_webhook || !editForm.id || alertTestLoading" @click="onTestAlert">
-              {{ alertTestLoading ? '发送中...' : '发送测试消息' }}
-            </button>
           </div>
         </template>
       </div>
@@ -332,7 +334,7 @@ import {
   pauseScheduleApi,
   resumeScheduleApi,
   runNowApi,
-  alertTestApi,
+  getNotifiers,
 } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import InlineConfirmDelete from './InlineConfirmDelete.vue';
@@ -345,12 +347,15 @@ const props = defineProps({
 // ---- State ----
 const loading = ref(false);
 const schedules = ref([]);
+const notifiers = ref([]);
+async function loadNotifiers() {
+  try { notifiers.value = await getNotifiers(); } catch { notifiers.value = []; }
+}
 const showCreateForm = ref(false);
 const createLoading = ref(false);
 const deleteCandidate = ref(null);
 const showEditForm = ref(false);
 const editLoading = ref(false);
-const alertTestLoading = ref(false);
 
 // ---- Profile data ----
 const profileModels = computed(() => {
@@ -384,7 +389,7 @@ function defaultCreateForm() {
     system_prompt: 'You are a helpful assistant.',
     user_prompt: 'Write a short essay about the future of artificial intelligence in exactly 200 words.',
     alert_enabled: false,
-    alert_webhook: '',
+    alert_notifier_id: 0,
     alert_threshold: 90,
   };
 }
@@ -424,7 +429,7 @@ const editForm = ref({
   system_prompt: '',
   user_prompt: '',
   alert_enabled: false,
-  alert_webhook: '',
+  alert_notifier_id: 0,
   alert_threshold: 90,
 });
 
@@ -501,7 +506,7 @@ function startEdit(s) {
     system_prompt: configs.system_prompt || '',
     user_prompt: configs.user_prompt || '',
     alert_enabled: !!s.alert_enabled,
-    alert_webhook: s.alert_webhook || '',
+    alert_notifier_id: s.alert_notifier_id || 0,
     alert_threshold: s.alert_threshold != null ? s.alert_threshold : 90,
   };
   // Detect preset or custom
@@ -605,7 +610,7 @@ async function createSchedule() {
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
-      alert_webhook: f.alert_webhook || '',
+      alert_notifier_id: f.alert_notifier_id || 0,
       alert_threshold: parseInt(f.alert_threshold) || 90,
     };
     const res = await createScheduleApi(payload);
@@ -652,7 +657,7 @@ async function saveEdit() {
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
-      alert_webhook: f.alert_webhook || '',
+      alert_notifier_id: f.alert_notifier_id || 0,
       alert_threshold: parseInt(f.alert_threshold) || 90,
     });
     if (res.error) {
@@ -666,19 +671,6 @@ async function saveEdit() {
     toast('更新失败: ' + e.message, 'error');
   }
   editLoading.value = false;
-}
-
-async function onTestAlert() {
-  const id = editForm.value.id;
-  if (!id) return;
-  alertTestLoading.value = true;
-  try {
-    const r = await alertTestApi(id);
-    toast(r.ok ? '测试消息已发送，请检查飞书' : '发送失败，请检查 URL', r.ok ? 'success' : 'error');
-  } catch (e) {
-    toast('发送失败：' + (e.message || e), 'error');
-  }
-  alertTestLoading.value = false;
 }
 
 async function pauseSchedule(id) {
@@ -729,6 +721,7 @@ function handleDocClick(e) {
 
 onMounted(() => {
   refreshSchedules();
+  loadNotifiers();
   document.addEventListener('mousedown', handleDocClick);
 });
 onUnmounted(() => {

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -107,6 +107,7 @@
                 <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
               </select>
               <div class="form-hint">在「设置」页管理告警器</div>
+              <div class="form-hint" style="color:var(--danger)" v-if="createForm.alert_notifier_id === 0">⚠️ 已开启告警但未选择告警器，将不会发送通知</div>
             </div>
             <div class="form-group">
               <label class="form-label">成功率阈值（%）</label>
@@ -305,6 +306,7 @@
               <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
             </select>
             <div class="form-hint">在「设置」页管理告警器</div>
+            <div class="form-hint" style="color:var(--danger)" v-if="editForm.alert_notifier_id === 0">⚠️ 已开启告警但未选择告警器，将不会发送通知</div>
           </div>
           <div class="form-group">
             <label class="form-label">成功率阈值（%）</label>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -50,6 +50,13 @@
         </div>
         <div class="settings-msg" v-show="passwordMsg" :class="passwordMsgType">{{ passwordMsg }}</div>
       </div>
+
+      <div class="card" style="margin-top:20px">
+        <div class="card-header">
+          <div class="card-title">告警器</div>
+        </div>
+        <NotifiersManager />
+      </div>
     </div>
   </section>
 </template>
@@ -59,6 +66,7 @@ import { ref } from 'vue';
 import { useAppStore } from '../stores/app';
 import { updateProfileApi, changePasswordApi } from '../api';
 import { toast } from '../composables/useToast';
+import NotifiersManager from '../components/NotifiersManager.vue';
 
 const store = useAppStore();
 const displayName = ref(store.user?.display_name || '');

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -241,6 +241,7 @@
                 <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
               </select>
               <div class="form-hint">在「设置」页管理告警器</div>
+              <div class="form-hint" style="color:var(--danger)" v-if="createForm.alert_notifier_id === 0">⚠️ 已开启告警但未选择告警器，将不会发送通知</div>
             </div>
             <div class="form-group">
               <label class="form-label">成功率阈值（%）</label>

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -235,8 +235,12 @@
           </label>
           <div class="create-modal-grid" v-if="createForm.alert_enabled" style="grid-template-columns:1fr;margin-top:12px">
             <div class="form-group">
-              <label class="form-label">飞书 Webhook URL</label>
-              <input class="form-input" v-model.trim="createForm.alert_webhook" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/...">
+              <label class="form-label">告警器</label>
+              <select class="form-input" v-model.number="createForm.alert_notifier_id" style="width:280px">
+                <option :value="0">未选择</option>
+                <option v-for="n in notifiers" :key="n.id" :value="n.id">{{ n.name }}</option>
+              </select>
+              <div class="form-hint">在「设置」页管理告警器</div>
             </div>
             <div class="form-group">
               <label class="form-label">成功率阈值（%）</label>
@@ -260,7 +264,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useAppStore } from '../stores/app';
-import { getSchedules, getProfiles, createScheduleApi, pauseScheduleApi, resumeScheduleApi, runNowApi, deleteScheduleApi } from '../api/index.js';
+import { getSchedules, getProfiles, createScheduleApi, pauseScheduleApi, resumeScheduleApi, runNowApi, deleteScheduleApi, getNotifiers } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import { useRoute } from 'vue-router';
 import InlineConfirmDelete from '../components/InlineConfirmDelete.vue';
@@ -312,7 +316,7 @@ function handleDocClick(e) {
 }
 
 function resetCreateForm() {
-  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_webhook: '', alert_threshold: 90 };
+  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_notifier_id: 0, alert_threshold: 90 };
   frequencyPreset.value = '300';
   profileDropdownOpen.value = false;
   freqDropdownOpen.value = false;
@@ -321,7 +325,11 @@ function resetCreateForm() {
   showAlert.value = false;
 }
 
-const createForm = ref({ name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_webhook: '', alert_threshold: 90 });
+const createForm = ref({ name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_notifier_id: 0, alert_threshold: 90 });
+const notifiers = ref([]);
+async function loadNotifiers() {
+  try { notifiers.value = await getNotifiers(); } catch { notifiers.value = []; }
+}
 
 const selectedProfileModels = computed(() => {
   const p = profiles.value.find(p => p.name === createForm.value.profile_name);
@@ -509,7 +517,7 @@ async function createSchedule() {
       schedule_type: 'interval',
       schedule_value: String(f.schedule_value),
       alert_enabled: !!f.alert_enabled,
-      alert_webhook: f.alert_webhook || '',
+      alert_notifier_id: f.alert_notifier_id || 0,
       alert_threshold: parseInt(f.alert_threshold) || 90,
     };
     const res = await createScheduleApi(payload);
@@ -577,6 +585,7 @@ async function loadData() {
     ]);
     schedules.value = schedData.schedules || [];
     profiles.value = Array.isArray(profData) ? profData : (profData.profiles || []);
+    loadNotifiers();
   } catch (e) {
     toast('加载定时任务失败: ' + e.message, 'error');
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ async def setup_db():
     """每个测试前重新初始化数据库"""
     async with engine.begin() as conn:
         from sqlalchemy import text
-        for table in ["channel_diagnostics", "scheduled_tasks", "user_settings", "results", "profiles", "sessions", "users"]:
+        for table in ["channel_diagnostics", "notifiers", "scheduled_tasks", "user_settings", "results", "profiles", "sessions", "users"]:
             await conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
     await init_db()
     await migrate()

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -86,6 +86,14 @@ async def test_notifier_create_rejects_bad_webhook(client):
 
 
 @pytest.mark.asyncio
+async def test_notifier_create_rejects_duplicate_name(client):
+    headers = await auth_headers(client)
+    await client.post("/api/notifiers", json={"name": "dup", "webhook": "https://open.feishu.cn/hook/d1"}, headers=headers)
+    r = await client.post("/api/notifiers", json={"name": "dup", "webhook": "https://open.feishu.cn/hook/d2"}, headers=headers)
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_notifier_delete_guard(client):
     headers = await auth_headers(client)
     await _make_profile(client, headers)
@@ -96,7 +104,7 @@ async def test_notifier_delete_guard(client):
     }, headers=headers)
     r = await client.delete(f"/api/notifiers/{nid}", headers=headers)
     assert r.status_code == 409
-    assert "1" in str(r.json())
+    assert r.json()["refs"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -11,29 +11,42 @@ async def _make_profile(client, headers):
     }, headers=headers)
 
 
+async def _make_notifier(client, headers, name="g", webhook="https://open.feishu.cn/hook/x"):
+    resp = await client.post("/api/notifiers",
+                             json={"name": name, "webhook": webhook}, headers=headers)
+    return resp.json()["id"]
+
+
 @pytest.mark.asyncio
-async def test_create_schedule_with_alert(client):
+async def test_create_schedule_with_notifier(client):
     headers = await auth_headers(client)
     await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
     resp = await client.post("/api/schedules", json={
         "name": "t", "profile_ids": ["s"], "schedule_value": "300",
-        "alert_enabled": True, "alert_threshold": 85,
-        "alert_webhook": "https://open.feishu.cn/x",
+        "alert_enabled": True, "alert_notifier_id": nid, "alert_threshold": 88,
     }, headers=headers)
     assert resp.status_code == 200
     sid = resp.json()["id"]
     row = await get_scheduled_task(sid)
-    assert row["alert_threshold"] == 85
-    assert row["alert_webhook"] == "https://open.feishu.cn/x"
+    assert row["alert_notifier_id"] == nid and row["alert_threshold"] == 88
 
 
 @pytest.mark.asyncio
-async def test_create_schedule_rejects_bad_webhook(client):
-    headers = await auth_headers(client)
-    await _make_profile(client, headers)
+async def test_create_schedule_rejects_foreign_notifier(client):
+    from tests.conftest import login_and_get_token
+    headers_a = await auth_headers(client)
+    nid_a = await _make_notifier(client, headers_a)
+    await client.post("/api/auth/register", json={
+        "email": "b2@example.com", "password": "pw12345678", "display_name": "B2",
+    })
+    token_b = await login_and_get_token(client, "b2@example.com", "pw12345678")
+    headers_b = {"Authorization": f"Bearer {token_b}"}
+    await _make_profile(client, headers_b)
     resp = await client.post("/api/schedules", json={
-        "name": "t", "profile_ids": ["s"], "alert_webhook": "https://evil.com/x",
-    }, headers=headers)
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid_a,
+    }, headers=headers_b)
     assert resp.status_code == 400
 
 
@@ -48,53 +61,69 @@ async def test_create_schedule_rejects_bad_threshold(client):
 
 
 @pytest.mark.asyncio
-async def test_alert_test_endpoint(client, monkeypatch):
-    sent = []
+async def test_notifier_crud_api(client):
+    headers = await auth_headers(client)
+    r = await client.post("/api/notifiers",
+                          json={"name": "群A", "webhook": "https://open.feishu.cn/hook/aaa"},
+                          headers=headers)
+    assert r.status_code == 200
+    nid = r.json()["id"]
+    items = (await client.get("/api/notifiers", headers=headers)).json()
+    assert len(items) == 1
+    assert items[0]["webhook"] != "https://open.feishu.cn/hook/aaa"
+    assert "open.feishu.cn" in items[0]["webhook"]
+    r2 = await client.put(f"/api/notifiers/{nid}", json={"name": "群A改"}, headers=headers)
+    assert r2.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_notifier_create_rejects_bad_webhook(client):
+    headers = await auth_headers(client)
+    r = await client.post("/api/notifiers",
+                          json={"name": "x", "webhook": "http://evil.com/h"},
+                          headers=headers)
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_notifier_delete_guard(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
+    await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid,
+    }, headers=headers)
+    r = await client.delete(f"/api/notifiers/{nid}", headers=headers)
+    assert r.status_code == 409
+    assert "1" in str(r.json())
+
+
+@pytest.mark.asyncio
+async def test_notifier_test_endpoint(client, monkeypatch):
+    sent = {}
 
     async def fake_send(url, payload, timeout=10.0):
-        sent.append(url)
+        sent["url"] = url
         return True
 
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-
     headers = await auth_headers(client)
-    await _make_profile(client, headers)
-    resp = await client.post("/api/schedules", json={
-        "name": "t", "profile_ids": ["s"], "alert_enabled": True,
-        "alert_webhook": "https://open.feishu.cn/x",
-    }, headers=headers)
-    sid = resp.json()["id"]
-
-    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
+    nid = await _make_notifier(client, headers)
+    r = await client.post(f"/api/notifiers/{nid}/test", headers=headers)
     assert r.status_code == 200 and r.json()["ok"] is True
-    assert len(sent) == 1
+    assert sent["url"].startswith("https://open.feishu.cn")
 
 
 @pytest.mark.asyncio
-async def test_alert_test_rejects_other_user(client):
+async def test_notifier_rejects_other_user(client):
     from tests.conftest import login_and_get_token
     headers_a = await auth_headers(client)
-    await _make_profile(client, headers_a)
-    sid = (await client.post("/api/schedules", json={
-        "name": "t", "profile_ids": ["s"], "alert_enabled": True,
-        "alert_webhook": "https://open.feishu.cn/x",
-    }, headers=headers_a)).json()["id"]
-
+    nid = await _make_notifier(client, headers_a)
     await client.post("/api/auth/register", json={
-        "email": "other@example.com", "password": "AITokenPerf#123", "display_name": "B",
+        "email": "b3@example.com", "password": "pw12345678", "display_name": "B3",
     })
-    token_b = await login_and_get_token(client, "other@example.com", "AITokenPerf#123")
+    token_b = await login_and_get_token(client, "b3@example.com", "pw12345678")
     headers_b = {"Authorization": f"Bearer {token_b}"}
-
-    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers_b)
+    r = await client.delete(f"/api/notifiers/{nid}", headers=headers_b)
     assert r.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_alert_test_requires_webhook(client):
-    headers = await auth_headers(client)
-    await _make_profile(client, headers)
-    resp = await client.post("/api/schedules", json={"name": "t", "profile_ids": ["s"]}, headers=headers)
-    sid = resp.json()["id"]
-    r = await client.post(f"/api/schedules/{sid}/alert-test", headers=headers)
-    assert r.status_code == 400

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -135,3 +135,7 @@ async def test_notifier_rejects_other_user(client):
     headers_b = {"Authorization": f"Bearer {token_b}"}
     r = await client.delete(f"/api/notifiers/{nid}", headers=headers_b)
     assert r.status_code == 404
+    r_put = await client.put(f"/api/notifiers/{nid}", json={"name": "x"}, headers=headers_b)
+    assert r_put.status_code == 404
+    r_test = await client.post(f"/api/notifiers/{nid}/test", headers=headers_b)
+    assert r_test.status_code == 404

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -59,3 +59,18 @@ async def test_get_run_success_rate_aggregates():
 async def test_get_run_success_rate_empty():
     assert await get_run_success_rate([]) == (0, 0)
     assert await get_run_success_rate(["nope"]) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_notifier_table_and_task_column_exist():
+    from app.db import engine
+    from sqlalchemy import text
+    async with engine.connect() as conn:
+        # notifiers 表可插入
+        await conn.execute(text(
+            "INSERT INTO notifiers (user_id, name, type, webhook) "
+            "VALUES (1, 'n1', 'feishu', 'https://open.feishu.cn/x')"))
+        # scheduled_tasks 有 alert_notifier_id 列（默认 0）
+        cur = await conn.execute(text(
+            "SELECT alert_notifier_id FROM scheduled_tasks LIMIT 0"))
+        assert cur is not None

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -12,28 +12,12 @@ from app.db import (
 
 
 @pytest.mark.asyncio
-async def test_alert_fields_roundtrip():
-    sid = await create_scheduled_task(
-        1, "t", [], {}, "interval", "300",
-        alert_webhook="https://open.feishu.cn/x", alert_threshold=80, alert_enabled=True,
-    )
-    row = await get_scheduled_task(sid)
-    assert row["alert_webhook"] == "https://open.feishu.cn/x"
-    assert row["alert_threshold"] == 80
-    assert bool(row["alert_enabled"]) is True
-    assert row["alert_state"] == "ok"
-
-
-@pytest.mark.asyncio
 async def test_update_alert_enabled_roundtrip():
     sid = await create_scheduled_task(1, "t3", [], {}, "interval", "300")
-    await update_scheduled_task(sid, alert_enabled=True, alert_webhook="https://open.feishu.cn/y")
-    row = await get_scheduled_task(sid)
-    assert bool(row["alert_enabled"]) is True
-    assert row["alert_webhook"] == "https://open.feishu.cn/y"
+    await update_scheduled_task(sid, alert_enabled=True)
+    assert bool((await get_scheduled_task(sid))["alert_enabled"]) is True
     await update_scheduled_task(sid, alert_enabled=False)
-    row2 = await get_scheduled_task(sid)
-    assert bool(row2["alert_enabled"]) is False
+    assert bool((await get_scheduled_task(sid))["alert_enabled"]) is False
 
 
 @pytest.mark.asyncio
@@ -59,6 +43,19 @@ async def test_get_run_success_rate_aggregates():
 async def test_get_run_success_rate_empty():
     assert await get_run_success_rate([]) == (0, 0)
     assert await get_run_success_rate(["nope"]) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_create_task_with_notifier_id():
+    from app.db import create_user, create_notifier, create_scheduled_task, get_scheduled_task
+    uid = await create_user("tnid@example.com", "pw")
+    nid = await create_notifier(uid, "g", "https://open.feishu.cn/hook/z")
+    sid = await create_scheduled_task(uid, "t", ["s"], {}, "interval", "300",
+                                      alert_notifier_id=nid, alert_threshold=80,
+                                      alert_enabled=True)
+    row = await get_scheduled_task(sid)
+    assert row["alert_notifier_id"] == nid
+    assert row["alert_threshold"] == 80
 
 
 @pytest.mark.asyncio

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -62,15 +62,22 @@ async def test_get_run_success_rate_empty():
 
 
 @pytest.mark.asyncio
-async def test_notifier_table_and_task_column_exist():
+async def test_notifier_defaults():
     from app.db import engine
     from sqlalchemy import text
-    async with engine.connect() as conn:
-        # notifiers 表可插入
+    async with engine.begin() as conn:
+        # 只给 user_id/name，type/webhook 走默认值
         await conn.execute(text(
-            "INSERT INTO notifiers (user_id, name, type, webhook) "
-            "VALUES (1, 'n1', 'feishu', 'https://open.feishu.cn/x')"))
-        # scheduled_tasks 有 alert_notifier_id 列（默认 0）
-        cur = await conn.execute(text(
-            "SELECT alert_notifier_id FROM scheduled_tasks LIMIT 0"))
-        assert cur is not None
+            "INSERT INTO notifiers (user_id, name) VALUES (1, 'n1')"))
+        row = (await conn.execute(text(
+            "SELECT type, webhook FROM notifiers WHERE user_id = 1 AND name = 'n1'"
+        ))).mappings().one()
+        assert row["type"] == "feishu"
+        assert row["webhook"] == ""
+
+
+@pytest.mark.asyncio
+async def test_task_alert_notifier_id_default_zero():
+    sid = await create_scheduled_task(1, "t", [], {}, "interval", "300")
+    row = await get_scheduled_task(sid)
+    assert row["alert_notifier_id"] == 0

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -81,3 +81,34 @@ async def test_task_alert_notifier_id_default_zero():
     sid = await create_scheduled_task(1, "t", [], {}, "interval", "300")
     row = await get_scheduled_task(sid)
     assert row["alert_notifier_id"] == 0
+
+
+@pytest.mark.asyncio
+async def test_notifier_crud_and_delete_guard():
+    from app.db import (create_user, create_notifier, list_notifiers,
+                        get_notifier, update_notifier, delete_notifier,
+                        create_scheduled_task, update_scheduled_task)
+    uid = await create_user("ntf@example.com", "pw")
+    nid = await create_notifier(uid, "运维群", "https://open.feishu.cn/hook/a")
+    # list
+    items = await list_notifiers(uid)
+    assert len(items) == 1 and items[0]["name"] == "运维群"
+    # get
+    n = await get_notifier(nid)
+    assert n["webhook"] == "https://open.feishu.cn/hook/a" and n["type"] == "feishu"
+    # update
+    await update_notifier(nid, name="新名", webhook="https://open.feishu.cn/hook/b")
+    assert (await get_notifier(nid))["name"] == "新名"
+    # update 留空 webhook = 不改
+    await update_notifier(nid, webhook="")
+    assert (await get_notifier(nid))["webhook"] == "https://open.feishu.cn/hook/b"
+    # 未被引用可删
+    ok, refs = await delete_notifier(nid)
+    assert ok is True and refs == 0
+    # 被任务引用则拒绝
+    nid2 = await create_notifier(uid, "群2", "https://open.feishu.cn/hook/c")
+    sid = await create_scheduled_task(uid, "t", ["s"], {}, "interval", "300")
+    await update_scheduled_task(sid, alert_notifier_id=nid2)
+    ok2, refs2 = await delete_notifier(nid2)
+    assert ok2 is False and refs2 == 1
+    assert await get_notifier(nid2) is not None  # 没被删

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -3,14 +3,15 @@ import json
 import pytest
 
 from app import notifier, scheduler
-from app.db import create_scheduled_task, save_result, get_scheduled_task, update_scheduled_task
+from app.db import create_scheduled_task, save_result, get_scheduled_task, update_scheduled_task, create_notifier
 
 
 async def _seed(rate_pair, alert_state="ok", enabled=True):
     succ, tot = rate_pair
+    nid = await create_notifier(1, "g", "https://open.feishu.cn/x")
     sid = await create_scheduled_task(
         1, "t", ["SiteA"], {}, "interval", "300",
-        alert_webhook="https://open.feishu.cn/x", alert_threshold=90, alert_enabled=enabled,
+        alert_notifier_id=nid, alert_threshold=90, alert_enabled=enabled,
     )
     if alert_state != "ok":
         await update_scheduled_task(sid, alert_state=alert_state)
@@ -58,9 +59,10 @@ async def test_no_alert_when_no_results(monkeypatch):
         sent.append(payload); return True
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
 
+    nid = await create_notifier(1, "g", "https://open.feishu.cn/x")
     sid = await create_scheduled_task(
         1, "t", ["SiteA"], {}, "interval", "300",
-        alert_webhook="https://open.feishu.cn/x", alert_threshold=90, alert_enabled=True,
+        alert_notifier_id=nid, alert_threshold=90, alert_enabled=True,
     )
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-empty"])
@@ -80,3 +82,34 @@ async def test_recover_when_back_to_normal(monkeypatch):
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
     assert len(sent) == 1
     assert (await get_scheduled_task(sid))["alert_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_alert_uses_notifier_webhook(monkeypatch):
+    sent = {}
+    async def fake_send(url, payload, timeout=10.0):
+        sent["url"] = url
+        return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed((0, 10))  # 0% < 90% 必触发
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent.get("url") == "https://open.feishu.cn/x"
+
+
+@pytest.mark.asyncio
+async def test_alert_skips_when_no_notifier(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(url)
+        return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    # alert_enabled 但没选告警器（notifier_id=0）→ 不发
+    sid = await create_scheduled_task(1, "tn", ["SiteA"], {}, "interval", "300",
+                                      alert_notifier_id=0, alert_threshold=90, alert_enabled=True)
+    await save_result(user_id=1, test_id="b", filename="b.json", timestamp="20260604_120000",
+                      config_json="{}", summary_json=json.dumps({"success_count": 0, "total_requests": 10}),
+                      percentiles_json="{}", run_id="run-2", scheduled_task_id=sid)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-2"])
+    assert sent == []

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -113,3 +113,21 @@ async def test_alert_skips_when_no_notifier(monkeypatch):
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-2"])
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_alert_skips_when_notifier_missing(monkeypatch):
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(url)
+        return True
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    # 指向一个不存在的告警器 id（如被删）→ 安全跳过
+    sid = await create_scheduled_task(1, "tm", ["SiteA"], {}, "interval", "300",
+                                      alert_notifier_id=999999, alert_threshold=90, alert_enabled=True)
+    await save_result(user_id=1, test_id="c", filename="c.json", timestamp="20260604_120000",
+                      config_json="{}", summary_json=json.dumps({"success_count": 0, "total_requests": 10}),
+                      percentiles_json="{}", run_id="run-3", scheduled_task_id=sid)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-3"])
+    assert sent == []


### PR DESCRIPTION
## 背景

原来飞书告警配置（webhook + 阈值 + 开关 + 状态）内联在每个定时任务里，一个任务写死一个 webhook，同一个飞书群要在多个任务里重复填、改地址要逐个改。

## 改动

把「通知配置」抽成可复用的全局 **告警器（notifier）**，创建/编辑定时任务时从下拉选告警器，而不是填 webhook。「发到哪」（告警器，可复用）和「啥时候发」（开关+阈值，任务自己的）彻底解耦。

- **数据模型**：新增 `notifiers` 表（按 user 隔离，name/type/webhook，`UNIQUE(user_id,name)`）；`scheduled_tasks` 加 `alert_notifier_id` 列（0=未选）。阈值/开关仍留任务上。旧 `alert_webhook` 列物理保留、停用不读写。
- **后端**：notifier CRUD API + 测试端点（`/api/notifiers/{id}/test`，从任务级 alert-test 迁移）；`_extract_alert_fields` 加归属校验；删除告警器被任务引用时拦截（同事务 COUNT+DELETE 防 TOCTOU，返回 409+引用数）；scheduler 改为按 `alert_notifier_id` 查实时 webhook，未选/缺失安全跳过。
- **前端**：新增「告警器管理」页（设置页内，增删改+测试）；两处任务表单（SiteSchedulesTab、TasksView）的 webhook 输入框换成告警器下拉。
- **安全**：写 webhook 入口走 SSRF 校验（限飞书域名）；列表返回脱敏 webhook（不漏 token）。

## 决策

- 告警器挂在定时任务层级（非站点 profile），触发逻辑仍为任务级整体成功率
- 不迁移旧内联 webhook，用户重新配
- 告警器按 user_id 隔离

设计/计划见 `docs/superpowers/specs/2026-06-05-notifier-decoupling-design.md` 与 `docs/superpowers/plans/2026-06-05-notifier-decoupling.md`。

## 测试

- 后端全量 `pytest tests/`：**268 passed, 0 failed**（含告警器 CRUD/删除拦截/跨用户隔离/脱敏/scheduler 实时 webhook 与缺失跳过等新用例）
- 前端 `bun run build`：通过
- grep 确认应用层无 `alert_webhook`/`alertTestApi`/`alert-test` 残留

## Test Plan
- [ ] 设置页新建/编辑/删除告警器，发送测试消息能收到飞书卡片
- [ ] 任务表单选告警器后，成功率跌破阈值能告警；恢复能发恢复卡片
- [ ] 删除被任务引用的告警器被拦截并提示
- [ ] 跨用户无法看到/使用他人告警器

Closes #33