### PR TITLE
提高用户定时任务数量上限（10 → 可配置，默认 50）

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -42,3 +42,8 @@ RESULTS_QUERY_MAX_ROWS = int(os.environ.get("RESULTS_QUERY_MAX_ROWS", "5000"))
 RESULTS_RETENTION_DAYS = int(os.environ.get("RESULTS_RETENTION_DAYS", "0"))
 # 保留策略扫描间隔（秒），默认每天一次。
 RESULTS_RETENTION_INTERVAL = int(os.environ.get("RESULTS_RETENTION_INTERVAL", "86400"))
+
+# 每个用户最多可创建的定时任务数量（任务定义存量上限）。
+# 与「同时运行的并发数」无关——后者由 BenchTaskManager.MAX_PER_USER 独立硬限制，
+# 故调大此值不会增加同时并发，仅放宽可保存的任务条数。
+MAX_SCHEDULES_PER_USER = int(os.environ.get("MAX_SCHEDULES_PER_USER", "50"))

--- a/app/server.py
+++ b/app/server.py
@@ -39,6 +39,7 @@ from app.auth import _is_public_path
 from app.config import (
     ALLOW_PROFILE_ENV_OVERRIDES,
     CORS_ORIGINS,
+    MAX_SCHEDULES_PER_USER,
     RUN_MAX_CHILDREN_PER_RUN,
     RUN_MAX_GLOBAL_SLOTS,
     RUN_MAX_USER_SLOTS,
@@ -2076,8 +2077,7 @@ async def create_schedule(request: Request, user: dict = Depends(get_current_use
     if not profile_ids:
         return JSONResponse({"error": "请至少选择一个 Profile"}, status_code=400)
 
-    # 定时任务数量限制
-    MAX_SCHEDULES_PER_USER = 10
+    # 定时任务数量限制（可配置，见 config.MAX_SCHEDULES_PER_USER）
     count = await count_user_scheduled_tasks(user_id)
     if count >= MAX_SCHEDULES_PER_USER:
         return JSONResponse({"error": f"定时任务数量已达上限（{MAX_SCHEDULES_PER_USER}个）"}, status_code=400)


### PR DESCRIPTION
## 改动
- `MAX_SCHEDULES_PER_USER` 从 server.py 内硬编码 `10` 移到 `app/config.py`，做成环境变量可配置，默认 **50**
- server.py 引用该常量，与现有限制（RUN_MAX_USER_SLOTS 等）写法一致

## 为什么安全（性能评估）
"能建多少任务" 与 "同时运行多少" 解耦：
- 同时运行的拨测由 `BenchTaskManager.MAX_PER_USER = 5`（server.py）独立硬限制
- 调度器领取到期任务时在 DB 级用 max_per_user 限并发（db.py）

调大数量只放宽"可保存的任务条数"，不增加同时并发，不会过载。

## 部署
如需进一步调整，设环境变量 `MAX_SCHEDULES_PER_USER` 即可，无需改代码。

Closes #38