### PR TITLE
站点配置体验改进：支持站点改名（级联更新）+ API Key 脱敏优化

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -640,6 +640,105 @@ async def delete_profile(user_id: int, name: str):
         )
 
 
+async def rename_profile(user_id: int, old_name: str, new_name: str) -> bool:
+    """将用户的 profile 从 old_name 改为 new_name，并在一个事务中级联更新所有引用。
+
+    返回 True 表示成功（包括 old==new 无需操作的情况）。
+    抛出 ValueError:
+      - new_name 为空
+      - old_name 不存在
+      - new_name 与该用户其它 profile 重名
+    """
+    new_name = (new_name or "").strip()
+    if not new_name:
+        raise ValueError("新名称不能为空")
+
+    # old == new：幂等，直接成功
+    if old_name == new_name:
+        return True
+
+    async with engine.begin() as conn:
+        # 校验 old_name 存在
+        cur = await conn.execute(
+            text("SELECT id FROM profiles WHERE user_id=:uid AND name=:name"),
+            {"uid": user_id, "name": old_name},
+        )
+        if not cur.fetchone():
+            raise ValueError(f"站点「{old_name}」不存在")
+
+        # 校验 new_name 不与其它 profile 重名
+        cur = await conn.execute(
+            text("SELECT id FROM profiles WHERE user_id=:uid AND name=:name"),
+            {"uid": user_id, "name": new_name},
+        )
+        if cur.fetchone():
+            raise ValueError(f"名称「{new_name}」已存在，请换一个名称")
+
+        # 1. profiles.name
+        await conn.execute(
+            text("UPDATE profiles SET name=:new WHERE user_id=:uid AND name=:old"),
+            {"uid": user_id, "new": new_name, "old": old_name},
+        )
+
+        # 2. results.profile_name（独立列）
+        await conn.execute(
+            text("UPDATE results SET profile_name=:new WHERE user_id=:uid AND profile_name=:old"),
+            {"uid": user_id, "new": new_name, "old": old_name},
+        )
+
+        # 3. results.config_json 内嵌的 profile_name（双方言）
+        if _is_sqlite:
+            await conn.execute(
+                text("""
+                    UPDATE results
+                    SET config_json = json_set(config_json, '$.profile_name', :new)
+                    WHERE user_id=:uid
+                      AND json_extract(config_json, '$.profile_name') = :old
+                """),
+                {"uid": user_id, "new": new_name, "old": old_name},
+            )
+        else:
+            await conn.execute(
+                text("""
+                    UPDATE results
+                    SET config_json = jsonb_set(config_json::jsonb, '{profile_name}', to_jsonb(:new))::text
+                    WHERE user_id=:uid
+                      AND config_json::jsonb->>'profile_name' = :old
+                """),
+                {"uid": user_id, "new": new_name, "old": old_name},
+            )
+
+        # 4. scheduled_tasks.profile_ids（JSON 字符串数组，Python 解析后替换再写回）
+        cur = await conn.execute(
+            text("SELECT id, profile_ids FROM scheduled_tasks WHERE user_id=:uid"),
+            {"uid": user_id},
+        )
+        tasks = cur.fetchall()
+        for task_row in tasks:
+            task_id, pids_raw = task_row[0], task_row[1]
+            try:
+                pids = json.loads(pids_raw) if pids_raw else []
+            except (json.JSONDecodeError, TypeError):
+                pids = []
+            if old_name in pids:
+                new_pids = [new_name if p == old_name else p for p in pids]
+                await conn.execute(
+                    text("UPDATE scheduled_tasks SET profile_ids=:pids WHERE id=:tid"),
+                    {"pids": json.dumps(new_pids), "tid": task_id},
+                )
+
+        # 5. channel_diagnostics.profile_name
+        await conn.execute(
+            text("UPDATE channel_diagnostics SET profile_name=:new WHERE user_id=:uid AND profile_name=:old"),
+            {"uid": user_id, "new": new_name, "old": old_name},
+        )
+
+        # 6. active profile：存在 profiles.is_active 列，随 profiles.name 一起在步骤 1 已经更新。
+        # （is_active 列没有关联 old_name 文本，步骤 1 UPDATE 已经把整行的 name 改过来了，无需额外操作。）
+
+    return True
+
+
 # ---- Notifiers CRUD ----
 
 async def create_notifier(user_id: int, name: str, webhook: str,

--- a/app/server.py
+++ b/app/server.py
@@ -24,7 +24,7 @@ from app.logger import log_access, log_security, current_run_id
 
 log = logging.getLogger("server")
 from app.db import init_db, close_db, get_profiles, get_active_profile, upsert_profile
-from app.db import switch_active_profile, delete_profile as db_delete_profile
+from app.db import switch_active_profile, delete_profile as db_delete_profile, rename_profile as db_rename_profile
 from app.db import save_result as db_save_result, get_results as db_get_results
 from app.db import get_results_aggregated as db_get_results_aggregated
 from app.db import get_result_by_filename, delete_result as db_delete_result
@@ -951,6 +951,23 @@ async def update_profile(name: str, request: Request, user: dict = Depends(get_c
         set_active=data.get("set_active", False),
     )
     return {"status": "ok"}
+
+
+@app.post("/api/profiles/{name}/rename")
+async def rename_profile_handler(name: str, request: Request, user: dict = Depends(get_current_user)):
+    """将站点改名并级联更新所有关联数据"""
+    data = await request.json()
+    new_name = (data.get("new_name") or "").strip()
+    if not new_name:
+        return JSONResponse({"error": "新名称不能为空"}, status_code=400)
+    try:
+        await db_rename_profile(user["user_id"], name, new_name)
+    except ValueError as e:
+        msg = str(e)
+        if "已存在" in msg or "already exists" in msg:
+            return JSONResponse({"error": msg}, status_code=400)
+        return JSONResponse({"error": msg}, status_code=404)
+    return {"status": "renamed", "name": new_name}
 
 
 @app.delete("/api/profiles/{name}")

--- a/app/server.py
+++ b/app/server.py
@@ -314,9 +314,10 @@ def _apply_env_overrides(config: dict) -> dict:
 
 
 def _mask_api_key(key: str) -> str:
-    if len(key) > 4:
-        return f"...{key[-4:]}"
-    return "****"
+    # 前后各保留 4 位便于辨认，中间打码；过短的 key 全打码避免过度暴露。
+    if len(key) <= 8:
+        return "****"
+    return f"{key[:4]}****{key[-4:]}"
 
 
 async def _resolve_profile_api_key(user_id: int, name: str, data: dict) -> str:

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -27,6 +27,7 @@ export const getProfiles = () => api('/api/profiles');
 export const createProfile = (data) => api('/api/profiles', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
 export const updateProfile = (name, data) => api(`/api/profiles/${encodeURIComponent(name)}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
 export const deleteProfileApi = (name) => api(`/api/profiles/${encodeURIComponent(name)}`, { method: 'DELETE' });
+export const renameProfile = (name, newName) => api(`/api/profiles/${encodeURIComponent(name)}/rename`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ new_name: newName }) });
 
 // Runs
 export const createRunApi = (data) => api('/api/runs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });

--- a/frontend/src/components/SiteConfigTab.vue
+++ b/frontend/src/components/SiteConfigTab.vue
@@ -7,10 +7,23 @@
 
       <!-- Config Form -->
       <div class="form-grid">
-        <!-- Site Name (readonly) -->
+        <!-- Site Name (with rename) -->
         <div class="form-group">
           <label class="form-label">站点名称</label>
-          <input class="form-input" :value="profile.name" readonly style="opacity:0.7;cursor:default">
+          <div v-if="!renaming" class="rename-row">
+            <input class="form-input" :value="profile.name" readonly style="opacity:0.7;cursor:default;flex:1">
+            <button class="btn btn-ghost btn-sm rename-btn" @click="startRename" title="改名">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+              改名
+            </button>
+          </div>
+          <div v-else class="rename-row">
+            <input class="form-input" v-model="renameValue" ref="renameInputRef"
+                   @keyup.enter="confirmRename" @keyup.esc="cancelRename"
+                   placeholder="输入新站点名称" style="flex:1">
+            <button class="btn btn-primary btn-sm" @click="confirmRename" :disabled="renaming && !renameValue.trim()">确认</button>
+            <button class="btn btn-ghost btn-sm" @click="cancelRename">取消</button>
+          </div>
         </div>
 
         <!-- Base URL -->
@@ -84,8 +97,9 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, nextTick } from 'vue';
 import { api } from '../api/index.js';
+import { renameProfile } from '../api/index.js';
 import { toast } from '../composables/useToast.js';
 import ModelSelector from './ModelSelector.vue';
 import ConnectivityProgress from './ConnectivityProgress.vue';
@@ -94,7 +108,7 @@ import { useConnectivityTest } from '../composables/useConnectivityTest.js';
 const props = defineProps({
   profile: { type: Object, required: true },
 });
-const emit = defineEmits(['deleted']);
+const emit = defineEmits(['deleted', 'renamed']);
 
 // ---- Form state ----
 const form = ref({
@@ -107,6 +121,52 @@ const showApiKey = ref(false);
 const confirmDelete = ref(false);
 const formDirty = ref(false);
 const savedConfig = ref(null);
+
+// ---- Rename state ----
+const renaming = ref(false);
+const renameValue = ref('');
+const renameInputRef = ref(null);
+
+function startRename() {
+  renameValue.value = props.profile.name;
+  renaming.value = true;
+  nextTick(() => {
+    if (renameInputRef.value) {
+      renameInputRef.value.focus();
+      renameInputRef.value.select();
+    }
+  });
+}
+
+function cancelRename() {
+  renaming.value = false;
+  renameValue.value = '';
+}
+
+async function confirmRename() {
+  const newName = renameValue.value.trim();
+  if (!newName) {
+    toast('新名称不能为空', 'info');
+    return;
+  }
+  if (newName === props.profile.name) {
+    cancelRename();
+    return;
+  }
+  try {
+    const res = await renameProfile(props.profile.name, newName);
+    if (res.error) {
+      toast('改名失败: ' + res.error, 'error');
+      return;
+    }
+    toast(`站点已改名为「${newName}」`, 'success');
+    renaming.value = false;
+    renameValue.value = '';
+    emit('renamed', newName);
+  } catch (e) {
+    toast('改名失败: ' + e.message, 'error');
+  }
+}
 
 // ---- Init form from profile ----
 function initForm() {
@@ -320,6 +380,17 @@ async function doDelete() {
 .form-hint {
   color: var(--text-tertiary);
   font-size: 12px;
+}
+
+.rename-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rename-btn {
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/SiteDetailView.vue
+++ b/frontend/src/views/SiteDetailView.vue
@@ -56,7 +56,7 @@
 
       <!-- Config Tab -->
       <div v-if="activeTab === 'config'" class="site-detail-panel">
-        <SiteConfigTab :profile="profile" @deleted="onSiteDeleted" />
+        <SiteConfigTab :profile="profile" @deleted="onSiteDeleted" @renamed="onSiteRenamed" />
       </div>
 
       <!-- Test Tab -->
@@ -162,6 +162,11 @@ function onClickOutside(e) {
 
 function onSiteDeleted() {
   router.push('/sites');
+}
+
+function onSiteRenamed(newName) {
+  // 改名后跳转到新 URL，并保持当前 tab
+  router.replace(`/sites/${encodeURIComponent(newName)}?tab=config`);
 }
 
 watch(() => route.params.id, () => {

--- a/tests/test_rename_profile.py
+++ b/tests/test_rename_profile.py
@@ -1,0 +1,126 @@
+"""测试 rename_profile 级联更新"""
+
+import json
+
+import pytest
+
+from app.db import (
+    create_user,
+    upsert_profile,
+    get_profiles,
+    create_scheduled_task,
+    get_scheduled_task,
+    save_result,
+    engine,
+    rename_profile,
+)
+from sqlalchemy import text
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_cascades():
+    """改名后 profiles / results / scheduled_tasks 全部同步"""
+    uid = await create_user("rename_test@example.com", "pw")
+
+    # 建 profile
+    await upsert_profile(uid, "OldSite", base_url="https://api.example.com",
+                         models=["gpt-4o"], set_active=True)
+
+    # 建一条结果，profile_name=OldSite
+    await save_result(
+        user_id=uid,
+        test_id="test-123",
+        filename="test-123.json",
+        timestamp="20260606_120000",
+        config_json=json.dumps({"profile_name": "OldSite", "base_url": "https://api.example.com"}),
+        summary_json=json.dumps({"success_count": 10, "total_requests": 10}),
+        percentiles_json="{}",
+        run_id="run-abc",
+    )
+
+    # 建一个定时任务，profile_ids 包含 OldSite
+    sid = await create_scheduled_task(uid, "daily-check", ["OldSite", "AnotherSite"],
+                                      {}, "interval", "300")
+
+    # 执行改名
+    result = await rename_profile(uid, "OldSite", "NewSite")
+    assert result is True, "rename_profile 应返回 True"
+
+    # 1. profiles.name 已更新
+    profiles = await get_profiles(uid)
+    names = [p["name"] for p in profiles]
+    assert "NewSite" in names, "profiles 中应有 NewSite"
+    assert "OldSite" not in names, "profiles 中不应有 OldSite"
+
+    # 2. results.profile_name 已更新
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text("SELECT profile_name, config_json FROM results WHERE user_id=:uid"),
+            {"uid": uid},
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "NewSite", f"results.profile_name 应为 NewSite，实为 {row[0]}"
+
+    # 3. results.config_json 内的 profile_name 已更新
+    cfg = json.loads(row[1])
+    assert cfg.get("profile_name") == "NewSite", \
+        f"config_json.profile_name 应为 NewSite，实为 {cfg.get('profile_name')}"
+
+    # 4. scheduled_tasks.profile_ids 中的 OldSite 已替换为 NewSite
+    task = await get_scheduled_task(sid)
+    pids = task.get("profile_ids") or []
+    assert "NewSite" in pids, f"profile_ids 应含 NewSite，实为 {pids}"
+    assert "OldSite" not in pids, f"profile_ids 不应含 OldSite，实为 {pids}"
+    assert "AnotherSite" in pids, "profile_ids 中其它元素应保留"
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_conflict():
+    """改名为已存在的名字应失败"""
+    uid = await create_user("rename_conflict@example.com", "pw")
+
+    await upsert_profile(uid, "SiteA", base_url="https://a.example.com", models=["m1"])
+    await upsert_profile(uid, "SiteB", base_url="https://b.example.com", models=["m1"])
+
+    with pytest.raises(ValueError, match=".*已存在.*|.*already exists.*"):
+        await rename_profile(uid, "SiteA", "SiteB")
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_same_name():
+    """old == new 时直接成功，无操作"""
+    uid = await create_user("rename_same@example.com", "pw")
+    await upsert_profile(uid, "MySite", base_url="https://api.example.com", models=["m1"])
+
+    result = await rename_profile(uid, "MySite", "MySite")
+    assert result is True
+
+    profiles = await get_profiles(uid)
+    names = [p["name"] for p in profiles]
+    assert "MySite" in names
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_not_found():
+    """改名不存在的 profile 应报错"""
+    uid = await create_user("rename_notfound@example.com", "pw")
+
+    with pytest.raises((ValueError, LookupError)):
+        await rename_profile(uid, "Ghost", "NewGhost")
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_active_profile():
+    """改名时 is_active 标记跟随新名字"""
+    uid = await create_user("rename_active@example.com", "pw")
+    await upsert_profile(uid, "ActiveSite", base_url="https://api.example.com",
+                         models=["m1"], set_active=True)
+
+    await rename_profile(uid, "ActiveSite", "RenamedSite")
+
+    from app.db import get_active_profile
+    active = await get_active_profile(uid)
+    assert active is not None
+    assert active["name"] == "RenamedSite", \
+        f"active profile 应跟随改名为 RenamedSite，实为 {active['name'] if active else None}"


### PR DESCRIPTION
## 1. 支持站点改名（带级联更新）
站点名称从只读改为可改名。改名时在一个事务里级联更新所有引用，历史/任务不断联：
- profiles.name
- results.profile_name（独立列）+ config_json 内嵌 profile_name（双方言 SQLite/PG）
- scheduled_tasks.profile_ids（JSON 数组内替换）
- channel_diagnostics.profile_name
- active profile（profiles.is_active 列随行更新）

校验：新名非空、不与其它站点重名（重名 400）。前端改名成功后自动跳转到新 URL。

## 2. API Key 脱敏优化
`_mask_api_key` 从"只显示后4位"改为"前后各4位"（如 `sk-a****wxyz`），便于辨认前缀；≤8位的短 key 全打码避免过度暴露。

## 测试
- 新增 tests/test_rename_profile.py，5 个用例全绿（级联/重名/同名/不存在/active）
- py_compile + bun build 通过

Closes #40