### PR TITLE
feat: 降低定时监控拨测的默认成本 (#42)

### DIFF
--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -84,7 +84,7 @@
           </div>
           <div class="form-group">
             <label class="form-label">最大 Token</label>
-            <input class="form-input" type="number" v-model.number="createForm.max_tokens" min="1" placeholder="512">
+            <input class="form-input" type="number" v-model.number="createForm.max_tokens" min="1" placeholder="16">
           </div>
         </div>
         <div class="form-grid" style="margin-top:12px">
@@ -94,7 +94,7 @@
           </div>
           <div class="form-group full">
             <label class="form-label">User Prompt</label>
-            <textarea class="form-input" v-model="createForm.user_prompt" rows="3" placeholder="Write a short essay about the future of artificial intelligence in exactly 200 words." maxlength="2000"></textarea>
+            <textarea class="form-input" v-model="createForm.user_prompt" rows="3" placeholder="Reply with: OK" maxlength="2000"></textarea>
           </div>
         </div>
         </div>
@@ -294,7 +294,7 @@
         </div>
         <div class="form-group full">
           <label class="form-label">User Prompt</label>
-          <textarea class="form-input" v-model="editForm.user_prompt" rows="3" placeholder="Write a short essay..." maxlength="2000"></textarea>
+          <textarea class="form-input" v-model="editForm.user_prompt" rows="3" placeholder="Reply with: OK" maxlength="2000"></textarea>
         </div>
       </div>
       <div class="form-grid" style="margin-top:12px">
@@ -391,11 +391,11 @@ function defaultCreateForm() {
     models: [],
     concurrency: 1,
     mode: 'burst',
-    max_tokens: 512,
+    max_tokens: 16,
     timeout: 120,
     duration: 120,
     system_prompt: 'You are a helpful assistant.',
-    user_prompt: 'Write a short essay about the future of artificial intelligence in exactly 200 words.',
+    user_prompt: 'Reply with: OK',
     alert_enabled: false,
     alert_notifier_id: 0,
     alert_threshold: 90,
@@ -609,7 +609,7 @@ async function createSchedule() {
       configs_json: {
         concurrency_levels: [parseInt(f.concurrency) || 1],
         mode: f.mode || 'burst',
-        max_tokens: parseInt(f.max_tokens) || 512,
+        max_tokens: parseInt(f.max_tokens) || 16,
         timeout: parseInt(f.timeout) || 120,
         duration: parseInt(f.duration) || 120,
         models: f.models,
@@ -651,7 +651,7 @@ async function saveEdit() {
     const configs = {
       concurrency_levels: [parseInt(f.concurrency) || 1],
       mode: f.mode || 'burst',
-      max_tokens: parseInt(f.max_tokens) || 512,
+      max_tokens: parseInt(f.max_tokens) || 16,
       timeout: parseInt(f.timeout) || 120,
       duration: parseInt(f.duration) || 120,
       models: f.models,

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -216,7 +216,7 @@
             </div>
             <div class="form-group">
               <label class="form-label">最大 Token</label>
-              <input class="form-input" type="number" v-model.number="createForm.max_tokens" min="1" placeholder="512">
+              <input class="form-input" type="number" v-model.number="createForm.max_tokens" min="1" placeholder="16">
             </div>
           </div>
         </div>
@@ -317,7 +317,7 @@ function handleDocClick(e) {
 }
 
 function resetCreateForm() {
-  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 512, timeout: 120, duration: 120, alert_enabled: false, alert_notifier_id: 0, alert_threshold: 90 };
+  createForm.value = { name: '', profile_name: '', schedule_value: 300, models: [], concurrency: 1, mode: 'burst', max_tokens: 16, timeout: 120, duration: 120, alert_enabled: false, alert_notifier_id: 0, alert_threshold: 90 };
   frequencyPreset.value = '300';
   profileDropdownOpen.value = false;
   freqDropdownOpen.value = false;
@@ -510,7 +510,7 @@ async function createSchedule() {
       configs_json: {
         concurrency_levels: [parseInt(f.concurrency) || 1],
         mode: f.mode || 'burst',
-        max_tokens: parseInt(f.max_tokens) || 512,
+        max_tokens: parseInt(f.max_tokens) || 16,
         timeout: parseInt(f.timeout) || 120,
         duration: parseInt(f.duration) || 120,
         models: f.models,


### PR DESCRIPTION
## Summary
- 定时监控创建表单默认 `max_tokens` 从 512 降到 16（可用性拨测只需看通不通，不需要长输出）
- 定时监控默认 `user_prompt` 从「写 200 词文章」改为 `Reply with: OK`，输出 token 从 ~400 压到 ~10
- 同步两处表单的输入框 placeholder，以及创建/编辑提交时的空值兜底 `|| 512 → || 16`

涉及文件：
- `frontend/src/components/SiteSchedulesTab.vue`（站点详情定时监控表单）
- `frontend/src/views/TasksView.vue`（任务管理页定时任务表单）

成本影响（并发 1、Sonnet 4.6 + Opus 4.7 + Opus 4.8、1 分钟一次）：输出从 ~400 token 压到 ~10，整体成本下降约 80%+。

## 未改动（避免误伤）
- 手动压测 `SiteTestTab.vue` —— 测性能需要真实负载
- 站点快速测试 `SitesView.vue` 的 quick_test —— 手动一次性
- 后端兜底默认 `app/protocols/*.py` 的 `max_tokens=512` —— 全局共用
- 编辑表单加载已有任务时仍读取任务自身的真实配置，存量任务不受影响

Closes #42

## Test plan
- [x] 前端 `bun run build` 通过
- [ ] 新建定时监控任务，确认 max_tokens 默认 16、user_prompt 为短文本
- [ ] 手动压测、站点快速测试的默认值不受影响
- [ ] 编辑已有定时任务，配置仍显示该任务的原始值