### PR TITLE
fix: 概况表指标修复（TTFT/TPOT/E2E + 延迟趋势） (#48)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1661,9 +1661,14 @@ async def get_sites_summary(user_id: int, hours: int | None = None) -> list[dict
                 s = json.loads(r[3])  # summary_json
             except (json.JSONDecodeError, TypeError):
                 s = {}
+            try:
+                p = json.loads(r[4]) if r[4] else {}  # percentiles_json
+            except (json.JSONDecodeError, TypeError):
+                p = {}
             latest_results.append({
                 "timestamp": r[2],
                 "summary": s,
+                "percentiles": p,
                 "config": json.loads(r[5]) if r[5] else {},
                 "scheduled_task_id": r[6],
             })

--- a/frontend/src/components/SiteOverviewTab.vue
+++ b/frontend/src/components/SiteOverviewTab.vue
@@ -28,9 +28,10 @@
             <th>模型</th>
             <th>TTFT P50</th>
             <th>TPOT P50</th>
+            <th>E2E P50</th>
             <th>Token/s</th>
             <th>成功率</th>
-            <th title="失败率变化趋势（7天）">趋势</th>
+            <th title="TTFT 延迟变化趋势（7天）">延迟趋势</th>
             <th>监控</th>
             <th>操作</th>
           </tr>
@@ -40,18 +41,25 @@
             <td class="overview-model">{{ m.model }}</td>
             <td :style="latencyColorStyle(m.ttft, 0.5, 2)">{{ fmtTime(m.ttft) }}</td>
             <td :style="latencyColorStyle(m.tpot, 0.01, 0.05)">{{ fmtTime(m.tpot) }}</td>
+            <td :style="latencyColorStyle(m.e2e, 1, 5)">{{ fmtTime(m.e2e) }}</td>
             <td class="overview-mono">{{ m.tps != null ? fmtNum(m.tps, 0) + ' t/s' : '-' }}</td>
             <td>
               <span class="rate-badge" :class="rateClass(m.successRate)">{{ fmtPct(m.successRate) }}</span>
             </td>
-            <td class="sparkline-cell" :title="sparklineTooltip(m.failRateTrend)">
-              <svg v-if="m.failRateTrend && m.failRateTrend.length >= 2" width="60" height="20" class="sparkline">
+            <td class="sparkline-cell" :title="latencyTrendTooltip(m.latencyTrend)">
+              <svg v-if="m.latencyTrend && m.latencyTrend.length >= 2" width="64" height="20" class="sparkline">
                 <polyline
-                  :points="sparklinePoints(m.failRateTrend)"
+                  :points="sparklinePoints(m.latencyTrend)"
                   fill="none"
-                  :stroke="m.failRateTrend[m.failRateTrend.length - 1] > m.failRateTrend[0] ? 'var(--danger)' : 'var(--success)'"
+                  :stroke="latencyTrendColor(m.latencyTrend)"
                   stroke-width="1.5"
                   stroke-linejoin="round"
+                />
+                <circle
+                  :cx="sparklineEnd(m.latencyTrend).x"
+                  :cy="sparklineEnd(m.latencyTrend).y"
+                  r="1.8"
+                  :fill="latencyTrendColor(m.latencyTrend)"
                 />
               </svg>
               <span v-else class="sparkline-na">-</span>
@@ -88,7 +96,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import { getSchedules } from '../api/index.js';
-import { getModelMetrics, sparklinePoints, sparklineTooltip, getErrorTypes, getTotalErrorCount, getDegradation } from '../utils/siteMetrics.js';
+import { getModelMetrics, sparklinePoints, sparklineEnd, latencyTrendColor, latencyTrendTooltip, getErrorTypes, getTotalErrorCount, getDegradation } from '../utils/siteMetrics.js';
 import { fmtTime, fmtPct, fmtNum, latencyColorStyle } from '../utils/formatters.js';
 import SiteTrendsTab from './SiteTrendsTab.vue';
 

--- a/frontend/src/utils/siteMetrics.js
+++ b/frontend/src/utils/siteMetrics.js
@@ -32,18 +32,30 @@ export function getModelMetrics(site) {
     const tpots = results.map(r => r.percentiles?.TPOT?.P50).filter(v => v != null);
     const tpot = tpots.length ? tpots.reduce((a, b) => a + b, 0) / tpots.length : null;
 
+    const e2es = results.map(r => r.percentiles?.E2E?.P50).filter(v => v != null);
+    const e2e = e2es.length ? e2es.reduce((a, b) => a + b, 0) / e2es.length : null;
+
     const tpsList = results.map(r => r.summary?.token_throughput_tps).filter(v => v != null && v > 0);
     const tps = tpsList.length ? tpsList.reduce((a, b) => a + b, 0) / tpsList.length : null;
 
-    // Sparkline trend: 失败率（从 latest_results 计算每次测试的失败率）
-    const failRateTrend = results.slice().reverse().map(r => {
-      const total = r.summary?.total_requests || 0;
-      const success = r.summary?.success_count || r.summary?.successful_requests || 0;
-      return total > 0 ? (100 - success / total * 100) : null;
-    }).filter(v => v != null);
+    // Sparkline: TTFT 延迟趋势（优先后端 7 天 sparkline_data，回退 latest_results）
+    const latencyTrend = getSparklineTrend(site, model);
 
-    return { model, ttft, failRateTrend, tpot, tps, successRate };
+    return { model, ttft, tpot, e2e, tps, successRate, latencyTrend };
   }).sort((a, b) => a.model.localeCompare(b.model));
+}
+
+// 取某模型的 TTFT 延迟趋势序列：优先后端 sparkline_data，回退 latest_results 的 TTFT P50
+export function getSparklineTrend(site, model) {
+  if (site.sparkline_data && site.sparkline_data[model]) {
+    return site.sparkline_data[model];
+  }
+  const results = site.latest_results || [];
+  const ttfts = results
+    .filter(r => r.config?.model === model)
+    .map(r => r.percentiles?.TTFT?.P50)
+    .filter(v => v != null);
+  return ttfts.slice(0, 10).reverse();
 }
 
 export function sparklinePoints(values) {
@@ -58,13 +70,36 @@ export function sparklinePoints(values) {
   }).join(' ');
 }
 
-export function sparklineTooltip(values) {
-  if (!values || values.length < 2) return '';
+// 延迟趋势 sparkline 末端点坐标（用于画当前点小圆点）
+export function sparklineEnd(values) {
+  if (!values || values.length < 2) return null;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const last = values[values.length - 1];
+  return { x: 60, y: 20 - ((last - min) / range) * 18 };
+}
+
+// 延迟趋势配色：延迟越低越好。上升=警示色，下降=绿色，基本持平=中性灰
+export function latencyTrendColor(values) {
+  if (!values || values.length < 2) return 'var(--text-tertiary)';
+  const first = values[0];
+  const last = values[values.length - 1];
+  if (first <= 0) return 'var(--text-tertiary)';
+  const pct = (last - first) / first;
+  if (pct > 0.05) return 'var(--danger)';
+  if (pct < -0.05) return 'var(--success)';
+  return 'var(--text-tertiary)';
+}
+
+export function latencyTrendTooltip(values) {
+  if (!values || values.length < 2) return '暂无足够趋势数据';
   const first = values[0];
   const last = values[values.length - 1];
   const diff = last - first;
   const arrow = diff > 0 ? '↑' : diff < 0 ? '↓' : '→';
-  return `失败率趋势: ${first.toFixed(1)}% → ${last.toFixed(1)}% (${arrow}${Math.abs(diff).toFixed(1)}%)`;
+  const pct = first > 0 ? Math.abs(diff / first * 100) : 0;
+  return `TTFT 延迟趋势(7天): ${first.toFixed(2)}s → ${last.toFixed(2)}s (${arrow}${pct.toFixed(0)}%)`;
 }
 
 export function getErrorTypes(site) {

--- a/frontend/src/views/SitesView.vue
+++ b/frontend/src/views/SitesView.vue
@@ -81,7 +81,7 @@
                 <tr>
                   <th>模型</th>
                   <th>TTFT P50</th>
-                  <th style="width:70px" title="失败率变化趋势">趋势</th>
+                  <th style="width:74px" title="TTFT 延迟变化趋势（7天）">延迟趋势</th>
                   <th>TPOT P50</th>
                   <th>Token/s</th>
                   <th>成功率</th>
@@ -91,11 +91,13 @@
                 <tr v-for="m in getModelMetrics(site)" :key="m.model">
                   <td class="matrix-model">{{ m.model }}</td>
                   <td :style="latencyColorStyle(m.ttft, 0.5, 2)">{{ fmtTime(m.ttft) }}</td>
-                  <td class="sparkline-cell" :title="sparklineTooltip(m.failRateTrend)">
-                    <svg v-if="m.failRateTrend && m.failRateTrend.length >= 2" width="60" height="20" class="sparkline">
-                      <polyline :points="sparklinePoints(m.failRateTrend)" fill="none"
-                        :stroke="m.failRateTrend[m.failRateTrend.length-1] > m.failRateTrend[0] ? 'var(--danger)' : 'var(--success)'"
+                  <td class="sparkline-cell" :title="latencyTrendTooltip(m.latencyTrend)">
+                    <svg v-if="m.latencyTrend && m.latencyTrend.length >= 2" width="64" height="20" class="sparkline">
+                      <polyline :points="sparklinePoints(m.latencyTrend)" fill="none"
+                        :stroke="latencyTrendColor(m.latencyTrend)"
                         stroke-width="1.5" stroke-linejoin="round" />
+                      <circle :cx="sparklineEnd(m.latencyTrend).x" :cy="sparklineEnd(m.latencyTrend).y"
+                        r="1.8" :fill="latencyTrendColor(m.latencyTrend)" />
                     </svg>
                     <span v-else class="sparkline-na">-</span>
                   </td>
@@ -197,7 +199,7 @@ import { useAppStore } from '../stores/app';
 import { useTimeRangeStore } from '../stores/timeRange';
 import { api, getSitesSummary } from '../api';
 import { fmtTime, fmtPct, fmtNum } from '../utils/formatters';
-import { getModelMetrics, sparklinePoints, sparklineTooltip, getErrorTypes, getTotalErrorCount, getDegradation } from '../utils/siteMetrics';
+import { getModelMetrics, sparklinePoints, sparklineEnd, latencyTrendColor, latencyTrendTooltip, getErrorTypes, getTotalErrorCount, getDegradation } from '../utils/siteMetrics';
 import { toast } from '../composables/useToast';
 import { useRouter, useRoute } from 'vue-router';
 import ModalOverlay from '../components/ModalOverlay.vue';


### PR DESCRIPTION
## Summary
- **修复 TTFT/TPOT 为空**：`get_sites_summary` 的 `latest_results` 此前未带 `percentiles`，前端读不到 → 后端透传 `percentiles`。
- **新增 E2E P50 列**：概况表加一列 E2E P50（数据已存在）。
- **趋势列改为延迟趋势**：原来是失败率（几乎恒为 0 的贴底绿线，无信息量）。改用后端已算好的 7 天 TTFT 趋势 `sparkline_data`（回退 latest_results）：延迟越低越好，上升=警示色、下降=绿色、持平=中性灰，末端加当前点圆点，tooltip 给绝对值与变化。表头改「延迟趋势」。
- 同步更新 `SitesView.vue` 的同款趋势列（共用 `siteMetrics.js`）。

> 趋势改为 TTFT 其实是 `timeRange.test.js` 早已写明的预期行为（优先用 sparkline_data），此前 `getModelMetrics` 未接上。

## 验证
- `bunx vitest run` 38 passed；`bun run build` 通过。
- 无头浏览器截图确认：TTFT/TPOT/E2E 三列有值；延迟趋势按方向配色（红/绿/灰）+ 末端点。

Closes #48

## Test plan
- [ ] TTFT/TPOT/E2E 正常显示
- [ ] 延迟趋势配色与 tooltip 正确
- [ ] 站点列表页（SitesView）趋势列同步正常