### PR TITLE
feat: 趋势图支持按模型筛选 (#49)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1214,8 +1214,9 @@ async def get_schedule_results_trend(user_id: int, scheduled_task_id: int, hours
     return result[-2000:]  # 最多2000个点
 
 
-async def get_site_trend(user_id: int, base_url: str, hours: int | None = None, profile_name: str | None = None) -> list[dict]:
-    """按站点聚合结果趋势。优先按 profile_name 精确过滤，回退到 base_url。"""
+async def get_site_trend(user_id: int, base_url: str, hours: int | None = None, profile_name: str | None = None, model: str | None = None) -> list[dict]:
+    """按站点聚合结果趋势。优先按 profile_name 精确过滤，回退到 base_url。
+    指定 model 时只统计该模型的结果。"""
     params: dict = {"uid": user_id}
     time_filter = ""
     if hours is not None:
@@ -1237,7 +1238,7 @@ async def get_site_trend(user_id: int, base_url: str, hours: int | None = None, 
 
     async with engine.connect() as conn:
         cur = await conn.execute(
-            text(f"""SELECT timestamp, summary_json, percentiles_json
+            text(f"""SELECT timestamp, summary_json, percentiles_json, config_json
                    FROM results
                    WHERE user_id=:uid
                      {site_filter}
@@ -1250,6 +1251,13 @@ async def get_site_trend(user_id: int, base_url: str, hours: int | None = None, 
 
     buckets = {}
     for row in rows:
+        if model:
+            try:
+                cfg = json.loads(row[3]) if row[3] else {}
+            except (json.JSONDecodeError, TypeError):
+                cfg = {}
+            if cfg.get("model") != model:
+                continue
         minute = row[0][:13]  # timestamp
         if minute not in buckets:
             buckets[minute] = {"minute": minute, "count": 0, "success_rates": [],

--- a/app/server.py
+++ b/app/server.py
@@ -845,12 +845,12 @@ async def sites_summary(hours: int | None = None, user: dict = Depends(get_curre
 
 
 @app.get("/api/sites/trend")
-async def get_site_trend_handler(base_url: str = "", profile_name: str | None = None, hours: int | None = None, user: dict = Depends(get_current_user)):
-    """按站点获取聚合趋势数据（轻量，只返回聚合点）"""
+async def get_site_trend_handler(base_url: str = "", profile_name: str | None = None, hours: int | None = None, model: str | None = None, user: dict = Depends(get_current_user)):
+    """按站点获取聚合趋势数据（轻量，只返回聚合点）。指定 model 时只看该模型。"""
     from app.db import get_site_trend as db_get_site_trend
     if not base_url and not profile_name:
         return JSONResponse({"error": "base_url or profile_name required"}, status_code=400)
-    trend = await db_get_site_trend(user["user_id"], base_url, hours=hours, profile_name=profile_name)
+    trend = await db_get_site_trend(user["user_id"], base_url, hours=hours, profile_name=profile_name, model=model)
     return {"trend": trend}
 
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -68,9 +68,10 @@ export const deleteNotifierApi = (id) => api(`/api/notifiers/${id}`, { method: '
 export const notifierTestApi = (id) => api(`/api/notifiers/${id}/test`, { method: 'POST' });
 
 // Sites
-export const getSiteTrend = (profileName, { hours } = {}) => {
+export const getSiteTrend = (profileName, { hours, model } = {}) => {
   const params = new URLSearchParams({ profile_name: profileName });
   if (hours) params.set('hours', hours);
+  if (model) params.set('model', model);
   return api(`/api/sites/trend?${params}`);
 };
 

--- a/frontend/src/components/SiteTrendsTab.vue
+++ b/frontend/src/components/SiteTrendsTab.vue
@@ -3,6 +3,17 @@
     <!-- Controls Bar -->
     <div class="trends-controls">
       <span class="trends-label">历史趋势</span>
+      <div v-if="modelOptions.length > 1" class="trend-model-filter">
+        <button class="trend-model-chip" :class="{ active: selectedModel === null }" @click="selectedModel = null">全部</button>
+        <button
+          v-for="mdl in modelOptions"
+          :key="mdl"
+          class="trend-model-chip"
+          :class="{ active: selectedModel === mdl }"
+          :title="mdl"
+          @click="selectedModel = mdl"
+        >{{ mdl }}</button>
+      </div>
     </div>
 
     <!-- Loading -->
@@ -137,6 +148,10 @@ const loading = ref(false);
 const trendData = ref([]);
 const trendSummary = ref([]);
 
+// 模型筛选：null = 全部
+const selectedModel = ref(null);
+const modelOptions = computed(() => props.profile?.models || []);
+
 const latencyCanvas = ref(null);
 const qualityCanvas = ref(null);
 let latencyChart = null;
@@ -251,7 +266,7 @@ async function fetchTrend() {
 
   loading.value = true;
   try {
-    const data = await getSiteTrend(profileName, { hours: timeRangeStore.hours });
+    const data = await getSiteTrend(profileName, { hours: timeRangeStore.hours, model: selectedModel.value });
     trendData.value = data.trend || [];
   } catch {
     trendData.value = [];
@@ -523,6 +538,11 @@ watch(() => timeRangeStore.hours, () => {
   loadRecords();
 });
 
+// 切换模型只刷新趋势图（执行记录表保留全部模型）
+watch(selectedModel, () => {
+  fetchTrend();
+});
+
 onUnmounted(() => {
   destroyCharts();
 });
@@ -547,6 +567,41 @@ onUnmounted(() => {
   font-size: 14px;
   font-weight: 700;
   color: var(--text-secondary);
+}
+
+.trend-model-filter {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.trend-model-chip {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.trend-model-chip:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.trend-model-chip.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
 }
 
 .trends-loading {


### PR DESCRIPTION
## Summary
- 后端 `get_site_trend` 增加 `model` 参数：SELECT 带上 config_json，指定模型时按 `config.model` 过滤。`/api/sites/trend` handler 透传 `model`。
- 前端 `getSiteTrend` 支持 `model` 入参；`SiteTrendsTab` 在「历史趋势」栏加模型筛选 chips（来自 `profile.models`），默认「全部」，切换只刷新趋势图（执行记录表保留全部模型）。

## 验证
- 后端（本地 sqlite，Aiberm 3 模型各 631 行）：全部=686 桶 / opus=631 / haiku=631 / 不存在模型=0。
- 前端无头截图：chips 渲染 + 选中态正确；选某模型后图表 X 轴/概要随之变化。
- `bunx vitest run` 38 passed；`bun run build` 通过。

Closes #49

## Test plan
- [ ] 多模型站点出现筛选 chips，单模型不显示
- [ ] 切换模型趋势图正确更新，默认「全部」行为不变