### PR TITLE
feat: 概况表点击模型行联动趋势 (#52)

### DIFF
--- a/frontend/src/components/SiteOverviewTab.vue
+++ b/frontend/src/components/SiteOverviewTab.vue
@@ -37,7 +37,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="m in modelMetrics" :key="m.model">
+          <tr
+            v-for="m in modelMetrics"
+            :key="m.model"
+            class="overview-row"
+            :class="{ 'row-active': selectedModel === m.model }"
+            :title="selectedModel === m.model ? '再次点击查看全部模型' : '点击只看该模型的趋势'"
+            @click="toggleModel(m.model)"
+          >
             <td class="overview-model">{{ m.model }}</td>
             <td :style="latencyColorStyle(m.ttft, 0.5, 2)">{{ fmtTime(m.ttft) }}</td>
             <td :style="latencyColorStyle(m.tpot, 0.01, 0.05)">{{ fmtTime(m.tpot) }}</td>
@@ -77,8 +84,8 @@
               </template>
             </td>
             <td class="overview-actions-cell">
-              <button class="btn btn-ghost btn-xs" @click="$emit('go-tab', 'test')" title="去测试">测试</button>
-              <button class="btn btn-ghost btn-xs" @click="scrollToTrends" title="查看趋势">趋势</button>
+              <button class="btn btn-ghost btn-xs" @click.stop="$emit('go-tab', 'test')" title="去测试">测试</button>
+              <button class="btn btn-ghost btn-xs" @click.stop="selectAndScroll(m.model)" title="查看该模型趋势">趋势</button>
             </td>
           </tr>
         </tbody>
@@ -87,7 +94,7 @@
 
     <!-- 内嵌趋势 -->
     <div ref="trendsRef" class="overview-trends-section">
-      <SiteTrendsTab :profile="profile" />
+      <SiteTrendsTab :profile="profile" :model-filter="selectedModel" @update:model-filter="selectedModel = $event" />
     </div>
 
   </div>
@@ -110,6 +117,18 @@ defineEmits(['go-tab']);
 const trendsRef = ref(null);
 const schedulesLoading = ref(false);
 const schedules = ref([]);
+
+// 模型筛选：点击表格行驱动下方趋势，null = 全部
+const selectedModel = ref(null);
+
+function toggleModel(model) {
+  selectedModel.value = selectedModel.value === model ? null : model;
+}
+
+function selectAndScroll(model) {
+  selectedModel.value = model;
+  scrollToTrends();
+}
 
 // 从 siteSummary 计算指标（若无数据则返回空数组）
 const modelMetrics = computed(() => {
@@ -291,8 +310,20 @@ onMounted(async () => {
   border-bottom: none;
 }
 
+.overview-table tbody tr.overview-row {
+  cursor: pointer;
+}
+
 .overview-table tbody tr:hover td {
   background: var(--border-subtle);
+}
+
+.overview-table tbody tr.row-active td {
+  background: var(--accent-light, color-mix(in srgb, var(--accent) 12%, transparent));
+}
+
+.overview-table tbody tr.row-active td.overview-model {
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .overview-model {

--- a/frontend/src/components/SiteTrendsTab.vue
+++ b/frontend/src/components/SiteTrendsTab.vue
@@ -3,16 +3,10 @@
     <!-- Controls Bar -->
     <div class="trends-controls">
       <span class="trends-label">历史趋势</span>
-      <div v-if="modelOptions.length > 1" class="trend-model-filter">
-        <button class="trend-model-chip" :class="{ active: selectedModel === null }" @click="selectedModel = null">全部</button>
-        <button
-          v-for="mdl in modelOptions"
-          :key="mdl"
-          class="trend-model-chip"
-          :class="{ active: selectedModel === mdl }"
-          :title="mdl"
-          @click="selectedModel = mdl"
-        >{{ mdl }}</button>
+      <div v-if="modelFilter" class="trend-model-active" :title="modelFilter">
+        <span class="trend-model-active-dot"></span>
+        <span class="trend-model-active-name">{{ modelFilter }}</span>
+        <button class="trend-model-clear" title="查看全部模型" @click="$emit('update:modelFilter', null)">&times;</button>
       </div>
     </div>
 
@@ -99,7 +93,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { getSiteTrend, getResults } from '../api';
 import { useTimeRangeStore } from '../stores/timeRange';
 import { aggregateToFixedPoints } from '../utils/trendAggregator.js';
@@ -139,7 +133,10 @@ const crosshairPlugin = {
 
 const props = defineProps({
   profile: { type: Object, required: true },
+  // 模型筛选：null = 全部，由概况表行点击驱动
+  modelFilter: { type: String, default: null },
 });
+defineEmits(['update:modelFilter']);
 
 const timeRangeStore = useTimeRangeStore();
 
@@ -147,10 +144,6 @@ const timeRangeStore = useTimeRangeStore();
 const loading = ref(false);
 const trendData = ref([]);
 const trendSummary = ref([]);
-
-// 模型筛选：null = 全部
-const selectedModel = ref(null);
-const modelOptions = computed(() => props.profile?.models || []);
 
 const latencyCanvas = ref(null);
 const qualityCanvas = ref(null);
@@ -266,7 +259,7 @@ async function fetchTrend() {
 
   loading.value = true;
   try {
-    const data = await getSiteTrend(profileName, { hours: timeRangeStore.hours, model: selectedModel.value });
+    const data = await getSiteTrend(profileName, { hours: timeRangeStore.hours, model: props.modelFilter });
     trendData.value = data.trend || [];
   } catch {
     trendData.value = [];
@@ -539,7 +532,7 @@ watch(() => timeRangeStore.hours, () => {
 });
 
 // 切换模型只刷新趋势图（执行记录表保留全部模型）
-watch(selectedModel, () => {
+watch(() => props.modelFilter, () => {
   fetchTrend();
 });
 
@@ -569,39 +562,54 @@ onUnmounted(() => {
   color: var(--text-secondary);
 }
 
-.trend-model-filter {
-  display: flex;
+.trend-model-active {
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
   gap: 6px;
+  max-width: 280px;
+  padding: 3px 6px 3px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  background: var(--accent-light, color-mix(in srgb, var(--accent) 12%, transparent));
+  border: 1px solid var(--accent);
+  border-radius: 14px;
 }
 
-.trend-model-chip {
-  max-width: 200px;
+.trend-model-active-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.trend-model-active-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 3px 10px;
-  font-size: 12px;
-  font-family: var(--font-mono);
+}
+
+.trend-model-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
   color: var(--text-secondary);
-  background: var(--surface-raised);
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
   cursor: pointer;
-  transition: all 0.15s;
+  flex-shrink: 0;
 }
 
-.trend-model-chip:hover {
-  border-color: var(--accent);
-  color: var(--text-primary);
-}
-
-.trend-model-chip.active {
+.trend-model-clear:hover {
   background: var(--accent);
-  border-color: var(--accent);
   color: #fff;
-  font-weight: 600;
 }
 
 .trends-loading {


### PR DESCRIPTION
## Summary
- 把 #49 的趋势区模型 chips 融入概况模型表：点击模型行即过滤下方延迟/质量趋势。
- `selectedModel` 状态上提到 `SiteOverviewTab`，通过 `v-model:modelFilter` 传给 `SiteTrendsTab`。
- 行点击 `toggleModel`：选中并高亮该行，再点同一行取消回到「全部」；行内「测试/趋势」按钮 `@click.stop`，「趋势」按钮选中该模型并滚动到趋势区。
- 移除趋势区原 chips；改为标题旁显示当前模型标签 + 清除（×）。

## 验证
- 无头浏览器截图：点 gpt-4o 行 → 行高亮、趋势联动（X 轴/概要变化）、「历史趋势」显示 `● gpt-4o ×`。
- `bunx vitest run` 38 passed；`bun run build` 通过。

Closes #52

## Test plan
- [ ] 点模型行联动趋势 + 行高亮
- [ ] 再点取消回到全部；× 清除可用
- [ ] 行内按钮点击不触发整行选中