### PR TITLE
feat: 切模型不整块刷新 + 执行记录按模型筛选 (#54)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -907,8 +907,8 @@ async def get_results(user_id: int, hours: int | None = None) -> list[dict]:
         return [_row_to_result_dict(row) for row in rows]
 
 
-async def get_results_aggregated(user_id: int, limit: int = 50, offset: int = 0, hours: int | None = None, lightweight: bool = False, raw: bool = False, base_url: str | None = None, profile_name: str | None = None) -> dict:
-    """返回历史记录。优先按 profile_name 精确过滤，回退到 base_url。"""
+async def get_results_aggregated(user_id: int, limit: int = 50, offset: int = 0, hours: int | None = None, lightweight: bool = False, raw: bool = False, base_url: str | None = None, profile_name: str | None = None, model: str | None = None) -> dict:
+    """返回历史记录。优先按 profile_name 精确过滤，回退到 base_url。指定 model 时只看该模型。"""
     params: dict = {"uid": user_id}
     time_filter = ""
     if hours is not None:
@@ -929,7 +929,16 @@ async def get_results_aggregated(user_id: int, limit: int = 50, offset: int = 0,
         params["base_url"] = base_clean
         params["base_url_slash"] = base_with_slash
 
-    where = f"WHERE r.user_id=:uid {time_filter} {site_filter}"
+    model_filter = ""
+    if model:
+        # config_json 是 TEXT，按方言取 JSON 字段
+        if _is_sqlite:
+            model_filter = "AND json_extract(r.config_json, '$.model') = :model"
+        else:
+            model_filter = "AND (r.config_json::jsonb ->> 'model') = :model"
+        params["model"] = model
+
+    where = f"WHERE r.user_id=:uid {time_filter} {site_filter} {model_filter}"
 
     # raw 模式：分页下推到 SQL（COUNT + LIMIT/OFFSET），不再全表加载进内存
     if raw:

--- a/app/server.py
+++ b/app/server.py
@@ -987,10 +987,11 @@ async def list_results(
     raw: bool = Query(False),
     base_url: str | None = Query(None),
     profile_name: str | None = Query(None),
+    model: str | None = Query(None),
     user: dict = Depends(get_current_user),
 ):
     lightweight = fields == "summary"
-    result = await db_get_results_aggregated(user["user_id"], limit=limit, offset=offset, hours=hours, lightweight=lightweight, raw=raw, base_url=base_url, profile_name=profile_name)
+    result = await db_get_results_aggregated(user["user_id"], limit=limit, offset=offset, hours=hours, lightweight=lightweight, raw=raw, base_url=base_url, profile_name=profile_name, model=model)
     resp = {"total": result["total"], "items": result["items"]}
     if result.get("truncated"):
         resp["truncated"] = True

--- a/frontend/src/components/SiteTrendsTab.vue
+++ b/frontend/src/components/SiteTrendsTab.vue
@@ -10,8 +10,8 @@
       </div>
     </div>
 
-    <!-- Loading -->
-    <div v-if="loading" class="trends-loading">
+    <!-- Loading：仅首次加载整块占位，之后切模型/时间范围原地更新 -->
+    <div v-if="loading && firstLoad" class="trends-loading">
       <div class="spinner"></div>
       <span>加载趋势数据...</span>
     </div>
@@ -142,6 +142,7 @@ const timeRangeStore = useTimeRangeStore();
 
 // ---- State ----
 const loading = ref(false);
+const firstLoad = ref(true);
 const trendData = ref([]);
 const trendSummary = ref([]);
 
@@ -191,6 +192,7 @@ async function loadRecords(page = 1) {
     };
     params.profile_name = profileName;
     if (timeRangeStore.hours) params.hours = timeRangeStore.hours;
+    if (props.modelFilter) params.model = props.modelFilter;
     const data = await getResults(params);
     records.value = data.items || [];
     recordsTotal.value = data.total || 0;
@@ -265,6 +267,7 @@ async function fetchTrend() {
     trendData.value = [];
   }
   loading.value = false;
+  firstLoad.value = false;
   destroyCharts();
   await nextTick();
   renderTrendSummary();
@@ -531,9 +534,10 @@ watch(() => timeRangeStore.hours, () => {
   loadRecords();
 });
 
-// 切换模型只刷新趋势图（执行记录表保留全部模型）
+// 切换模型：刷新趋势图 + 执行记录（回到第 1 页）
 watch(() => props.modelFilter, () => {
   fetchTrend();
+  loadRecords(1);
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- **问题1**：`SiteTrendsTab` 的 `loading` 原会把整块趋势区（概要卡+两图+执行记录）换成 spinner，切模型整块闪。改为新增 `firstLoad` 标志，仅首次加载显示整块占位，之后切模型/时间范围内容原地更新。
- **问题2**：`/api/results` 增加 `model` 参数（按 `config.model` 过滤，SQLite 用 `json_extract`、PG 用 `config_json::jsonb->>'model'`）；选中模型时执行记录同步筛选并回到第 1 页。

## 验证
- 后端（本地 sqlite，Aiberm）：全部 1893 / opus 631 / haiku 631。
- 无头浏览器：选 gpt-4o 后执行记录只剩 gpt-4o（断言通过），切换不再整块空白。
- `bunx vitest run` 38 passed；`bun run build` 通过。

Closes #54

## Test plan
- [ ] 切模型时仅图表/数据原地更新，无整块 spinner
- [ ] 执行记录随选中模型筛选；「全部」时显示所有模型