### PR TITLE
feat: 拨测告警按「站点×模型」细分，消除整体成功率稀释漏报

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -843,29 +843,6 @@ async def save_result(user_id: int, test_id: str, filename: str, timestamp: str,
         )
 
 
-async def get_run_success_rate(run_ids: list) -> tuple:
-    """聚合给定 run 的全部 result 行的 (success_count, total_requests)。返回 (success, total)。"""
-    if not run_ids:
-        return (0, 0)
-    placeholders = ",".join(f":r{i}" for i in range(len(run_ids)))
-    params = {f"r{i}": rid for i, rid in enumerate(run_ids)}
-    async with engine.connect() as conn:
-        cur = await conn.execute(
-            text(f"SELECT summary_json FROM results WHERE run_id IN ({placeholders})"),
-            params,
-        )
-        rows = cur.fetchall()
-    success = total = 0
-    for row in rows:
-        try:
-            s = json.loads(row[0])
-        except (json.JSONDecodeError, TypeError):
-            continue
-        success += int(s.get("success_count") or 0)
-        total += int(s.get("total_requests") or 0)
-    return (success, total)
-
-
 async def get_run_success_rate_by_cell(run_ids: list) -> dict:
     """按 (profile_name, model) 分组聚合本轮 result 行的 (success, total)。
     返回 {(profile, model): (success, total)}。无行返回 {}。"""

--- a/app/db.py
+++ b/app/db.py
@@ -866,6 +866,39 @@ async def get_run_success_rate(run_ids: list) -> tuple:
     return (success, total)
 
 
+async def get_run_success_rate_by_cell(run_ids: list) -> dict:
+    """按 (profile_name, model) 分组聚合本轮 result 行的 (success, total)。
+    返回 {(profile, model): (success, total)}。无行返回 {}。"""
+    if not run_ids:
+        return {}
+    placeholders = ",".join(f":r{i}" for i in range(len(run_ids)))
+    params = {f"r{i}": rid for i, rid in enumerate(run_ids)}
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text(f"SELECT profile_name, config_json, summary_json FROM results "
+                 f"WHERE run_id IN ({placeholders})"),
+            params,
+        )
+        rows = cur.fetchall()
+    cells: dict = {}
+    for profile_name, config_json, summary_json in rows:
+        try:
+            cfg = json.loads(config_json) if config_json else {}
+        except (json.JSONDecodeError, TypeError):
+            cfg = {}
+        try:
+            s = json.loads(summary_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        profile = profile_name or cfg.get("profile_name", "") or "-"
+        model = cfg.get("model") or "-"
+        succ = int(s.get("success_count") or 0)
+        tot = int(s.get("total_requests") or 0)
+        cur_s, cur_t = cells.get((profile, model), (0, 0))
+        cells[(profile, model)] = (cur_s + succ, cur_t + tot)
+    return cells
+
+
 def _row_to_result_dict(row, lightweight: bool = False) -> dict:
     d = dict(row._mapping)
     d["config"] = json.loads(d["config_json"])

--- a/app/db.py
+++ b/app/db.py
@@ -890,7 +890,8 @@ async def get_run_success_rate_by_cell(run_ids: list) -> dict:
             s = json.loads(summary_json)
         except (json.JSONDecodeError, TypeError):
             continue
-        profile = profile_name or cfg.get("profile_name", "") or "-"
+        # profile_name 列由 save_result 从 config_json 同源写入，是规范来源；空则归 "-"
+        profile = profile_name or "-"
         model = cfg.get("model") or "-"
         succ = int(s.get("success_count") or 0)
         tot = int(s.get("total_requests") or 0)

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -57,29 +57,34 @@ def is_allowed_webhook(url: str) -> bool:
     return p.hostname in FEISHU_ALLOWED_HOSTS
 
 
-def build_feishu_card(kind: str, task_name: str, profile: str,
-                      rate: float, threshold: int, ts: str) -> dict:
-    """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。"""
+def build_feishu_card(kind: str, task_name: str,
+                      cells: list, threshold: int, ts: str) -> dict:
+    """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
+    cells: [(profile, model, rate), ...] —— 本轮新翻转的格子。"""
     if kind == "recover":
         template, title, color = "green", "✅ 已恢复", "green"
     else:
         template, title, color = "red", "🔴 拨测告警", "red"
+    elements = [
+        {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},
+    ]
+    for profile, model, rate in cells:
+        elements.append({"tag": "div", "fields": [
+            {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
+            {"is_short": True, "text": {"tag": "lark_md", "content": f"**模型**\n{model}"}},
+            {"is_short": True, "text": {"tag": "lark_md",
+                "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
+        ]})
+    elements.append({"tag": "hr"})
+    elements.append({"tag": "note", "elements": [
+        {"tag": "lark_md", "content": f"阈值 {threshold}% · {ts} · AITokenPerf"}]})
     return {
         "msg_type": "interactive",
         "card": {
             "config": {"wide_screen_mode": True},
             "header": {"template": template,
                        "title": {"tag": "plain_text", "content": title}},
-            "elements": [
-                {"tag": "div", "fields": [
-                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**任务**\n{task_name}"}},
-                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
-                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
-                    {"is_short": True, "text": {"tag": "lark_md", "content": f"**阈值**\n{threshold}%"}},
-                ]},
-                {"tag": "hr"},
-                {"tag": "note", "elements": [{"tag": "lark_md", "content": f"⏰ {ts} · AITokenPerf"}]},
-            ],
+            "elements": elements,
         },
     }
 

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """告警通知模块：状态机判定 + 飞书卡片 + webhook 发送（SSRF 限飞书域名）。"""
 
+import json
 import logging
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -22,6 +23,17 @@ def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> Tupl
     if not abnormal and prev_state == ALERT_ALERTING:
         return ALERT_OK, "recover"
     return prev_state, None
+
+
+def _load_alert_states(raw) -> dict:
+    """读取 alert_state：合法 JSON dict 原样返回；裸值/空/非 dict 一律视为空（存量兼容）。"""
+    if not raw:
+        return {}
+    try:
+        v = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return v if isinstance(v, dict) else {}
 
 
 def _safe_host(url: str) -> str:

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -225,10 +225,11 @@ class TaskScheduler:
 # ── 模块级工具函数 ───────────────────────────────────────
 
 async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
-    """按落库结果聚合成功率，状态翻转时发飞书卡片并写回 alert_state。全程不抛。"""
-    from app.db import get_run_success_rate, get_notifier
-    # notifier 在函数内 import：保持 send_webhook 在调用时解析，便于测试 monkeypatch
-    from app.notifier import evaluate_alert, build_feishu_card, send_webhook
+    """按 (站点,模型) 格子聚合成功率，逐格状态翻转，聚合成红/绿卡发送。全程不抛。"""
+    from app.db import get_run_success_rate_by_cell, get_notifier
+    from app.notifier import (
+        evaluate_alert, build_feishu_card, send_webhook, _load_alert_states,
+    )
 
     notifier_id = task_row.get("alert_notifier_id") or 0
     if not task_row.get("alert_enabled") or not notifier_id:
@@ -238,21 +239,39 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     if not webhook:
         log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
         return
-    success, total = await get_run_success_rate(run_ids)
-    if total == 0:
+
+    cells = await get_run_success_rate_by_cell(run_ids)
+    if not cells:
         log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
         return
-    rate = success / total * 100
+
     threshold = int(task_row.get("alert_threshold") or 90)
-    prev = task_row.get("alert_state") or "ok"
-    new_state, action = evaluate_alert(prev, rate, threshold)
-    if action:
-        profiles_text = ", ".join(task_row.get("profile_ids", []) or []) or "-"
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        card = build_feishu_card(action, task_row.get("name", ""), profiles_text, rate, threshold, ts)
-        await send_webhook(webhook, card)
-    if new_state != prev:
-        await update_scheduled_task(task_id, alert_state=new_state)
+    prev = _load_alert_states(task_row.get("alert_state"))
+    new_states: dict = {}
+    alerts, recovers = [], []
+    for (profile, model), (succ, tot) in cells.items():
+        p_state = prev.get(profile, {}).get(model, "ok")
+        if tot == 0:                       # 没真发出请求 → 不评估、保留旧态
+            new_states.setdefault(profile, {})[model] = p_state
+            continue
+        rate = succ / tot * 100
+        n_state, action = evaluate_alert(p_state, rate, threshold)
+        new_states.setdefault(profile, {})[model] = n_state
+        if action == "alert":
+            alerts.append((profile, model, rate))
+        elif action == "recover":
+            recovers.append((profile, model, rate))
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    name = task_row.get("name", "")
+    if alerts:
+        await send_webhook(webhook, build_feishu_card("alert", name, alerts, threshold, ts))
+    if recovers:
+        await send_webhook(webhook, build_feishu_card("recover", name, recovers, threshold, ts))
+
+    if new_states != prev:
+        await update_scheduled_task(
+            task_id, alert_state=json.dumps(new_states, ensure_ascii=False))
 
 
 async def _run_scheduled_task(task_id: int):

--- a/app/server.py
+++ b/app/server.py
@@ -2317,7 +2317,7 @@ async def notifier_test(notifier_id: int, user: dict = Depends(get_current_user)
     if not webhook or not is_allowed_webhook(webhook):
         return JSONResponse({"error": "该告警器 webhook 非法"}, status_code=400)
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    card = build_feishu_card("alert", n.get("name", ""), "测试", 0.0, 90, ts)
+    card = build_feishu_card("alert", n.get("name", ""), [("测试", "测试", 0.0)], 90, ts)
     card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
     ok = await send_webhook(webhook, card)
     return {"ok": ok}

--- a/docs/superpowers/plans/2026-06-09-per-cell-alerting.md
+++ b/docs/superpowers/plans/2026-06-09-per-cell-alerting.md
@@ -1,0 +1,584 @@
+# 拨测告警「按站点×模型」细分 · 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把定时拨测告警从「任务级整体成功率」下沉到「每个 (站点 profile, 模型 model) 格子各自判断」，多格同时翻转时聚合成一条红卡/一条绿卡发飞书。
+
+**Architecture:** 纯后端策略改动。新增按格子分组的成功率聚合 DB 助手；`alert_state` 列复用、值改存 JSON（`{站点:{模型:状态}}`，老裸值兼容为空）；重写 `_maybe_send_alert` 逐格跑现有 `evaluate_alert` 并聚合发卡；`build_feishu_card` 改吃格子列表。零 DDL、零数据迁移、前端不动。
+
+**Tech Stack:** Python / asyncio / SQLAlchemy(async) / aiohttp / pytest+pytest-asyncio；测试用 SQLite（conftest autouse 重建表）。
+
+**Notes for executor:**
+- 工作目录是 worktree 根 `.claude/worktrees/issue-56-per-cell-alerting/`。
+- 跑测试用项目虚拟环境：`python -m pytest ...`；若 `ModuleNotFoundError`，改用 `.venv/bin/python -m pytest ...`。
+- 设计依据：`docs/superpowers/specs/2026-06-09-per-cell-alerting-design.md`。
+- 提交 commit message 引用 `#56`，**不要**加 `Co-Authored-By`。
+
+---
+
+## 文件结构
+
+| 文件 | 改动 |
+|---|---|
+| `app/db.py` | 新增 `get_run_success_rate_by_cell(run_ids)`；删除旧 `get_run_success_rate`（Task 3） |
+| `app/notifier.py` | 新增 `import json` + `_load_alert_states(raw)`；`build_feishu_card` 改吃格子列表 |
+| `app/scheduler.py` | 重写 `_maybe_send_alert`（分组 + 逐格判定 + 聚合发卡 + JSON 状态读写） |
+| `tests/test_alert_db.py` | 新增 3 个分组测试；删 2 个旧 `get_run_success_rate` 测试 + 改顶部 import（Task 3） |
+| `tests/test_notifier.py` | 新增 4 个 `_load_alert_states` 测试；改 2 个卡片测试为列表签名 |
+| `tests/test_alert_scheduler.py` | 整体重写为 per-cell 场景 |
+
+---
+
+## Task 1: 按格子分组的成功率聚合（`get_run_success_rate_by_cell`）
+
+**Files:**
+- Modify: `app/db.py`（在 `get_run_success_rate` 之后新增函数，约 `db.py:867`）
+- Test: `tests/test_alert_db.py`（文件末尾追加）
+
+- [ ] **Step 1: 写失败测试**
+
+追加到 `tests/test_alert_db.py` 末尾：
+
+```python
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_groups():
+    from app.db import get_run_success_rate_by_cell
+    rows = [
+        ("SiteA", "gpt-4o", 8, 10),
+        ("SiteA", "gpt-4o", 9, 10),   # 同格第二并发档，应累加
+        ("SiteA", "claude", 5, 10),
+        ("SiteB", "gpt-4o", 10, 10),
+    ]
+    for i, (pf, model, succ, tot) in enumerate(rows):
+        await save_result(
+            user_id=1, test_id=f"c{i}", filename=f"c{i}.json", timestamp="20260609_120000",
+            config_json=json.dumps({"profile_name": pf, "model": model}),
+            summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-cell",
+        )
+    cells = await get_run_success_rate_by_cell(["run-cell"])
+    assert cells[("SiteA", "gpt-4o")] == (17, 20)
+    assert cells[("SiteA", "claude")] == (5, 10)
+    assert cells[("SiteB", "gpt-4o")] == (10, 10)
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_model_missing():
+    from app.db import get_run_success_rate_by_cell
+    await save_result(
+        user_id=1, test_id="nm", filename="nm.json", timestamp="20260609_120000",
+        config_json=json.dumps({"profile_name": "SiteA"}),  # 无 model
+        summary_json=json.dumps({"success_count": 3, "total_requests": 4}),
+        percentiles_json="{}", run_id="run-nm",
+    )
+    cells = await get_run_success_rate_by_cell(["run-nm"])
+    assert cells[("SiteA", "-")] == (3, 4)
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_empty():
+    from app.db import get_run_success_rate_by_cell
+    assert await get_run_success_rate_by_cell([]) == {}
+    assert await get_run_success_rate_by_cell(["nope"]) == {}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_alert_db.py -k by_cell -v`
+Expected: FAIL —— `ImportError: cannot import name 'get_run_success_rate_by_cell'`
+
+- [ ] **Step 3: 实现函数**
+
+在 `app/db.py` 的 `get_run_success_rate`（结尾约 866 行）之后新增：
+
+```python
+async def get_run_success_rate_by_cell(run_ids: list) -> dict:
+    """按 (profile_name, model) 分组聚合本轮 result 行的 (success, total)。
+    返回 {(profile, model): (success, total)}。无行返回 {}。"""
+    if not run_ids:
+        return {}
+    placeholders = ",".join(f":r{i}" for i in range(len(run_ids)))
+    params = {f"r{i}": rid for i, rid in enumerate(run_ids)}
+    async with engine.connect() as conn:
+        cur = await conn.execute(
+            text(f"SELECT profile_name, config_json, summary_json FROM results "
+                 f"WHERE run_id IN ({placeholders})"),
+            params,
+        )
+        rows = cur.fetchall()
+    cells: dict = {}
+    for profile_name, config_json, summary_json in rows:
+        try:
+            cfg = json.loads(config_json) if config_json else {}
+        except (json.JSONDecodeError, TypeError):
+            cfg = {}
+        try:
+            s = json.loads(summary_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        profile = profile_name or cfg.get("profile_name", "") or "-"
+        model = cfg.get("model") or "-"
+        succ = int(s.get("success_count") or 0)
+        tot = int(s.get("total_requests") or 0)
+        cur_s, cur_t = cells.get((profile, model), (0, 0))
+        cells[(profile, model)] = (cur_s + succ, cur_t + tot)
+    return cells
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `python -m pytest tests/test_alert_db.py -k by_cell -v`
+Expected: 3 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/db.py tests/test_alert_db.py
+git commit -m "feat: 新增 get_run_success_rate_by_cell 按格子分组聚合成功率 (#56)"
+```
+
+---
+
+## Task 2: `alert_state` JSON 读取兼容（`_load_alert_states`）
+
+**Files:**
+- Modify: `app/notifier.py`（顶部加 `import json`；新增纯函数）
+- Test: `tests/test_notifier.py`（文件末尾追加）
+
+- [ ] **Step 1: 写失败测试**
+
+追加到 `tests/test_notifier.py` 末尾：
+
+```python
+def test_load_alert_states_valid_json():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states('{"SiteA": {"gpt-4o": "alerting"}}') == {"SiteA": {"gpt-4o": "alerting"}}
+
+
+def test_load_alert_states_legacy_scalar():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states("ok") == {}
+    assert _load_alert_states("alerting") == {}
+
+
+def test_load_alert_states_empty_or_none():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states("") == {}
+    assert _load_alert_states(None) == {}
+
+
+def test_load_alert_states_non_dict_json():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states('"ok"') == {}
+    assert _load_alert_states("123") == {}
+    assert _load_alert_states("[1, 2]") == {}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python -m pytest tests/test_notifier.py -k load_alert_states -v`
+Expected: FAIL —— `ImportError: cannot import name '_load_alert_states'`
+
+- [ ] **Step 3: 实现**
+
+在 `app/notifier.py` 顶部 import 区加（与现有 `import logging` 同组）：
+
+```python
+import json
+```
+
+在 `evaluate_alert` 之后新增：
+
+```python
+def _load_alert_states(raw) -> dict:
+    """读取 alert_state：合法 JSON dict 原样返回；裸值/空/非 dict 一律视为空（存量兼容）。"""
+    if not raw:
+        return {}
+    try:
+        v = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return v if isinstance(v, dict) else {}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `python -m pytest tests/test_notifier.py -k load_alert_states -v`
+Expected: 4 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/notifier.py tests/test_notifier.py
+git commit -m "feat: 新增 _load_alert_states 兼容读取告警状态 JSON (#56)"
+```
+
+---
+
+## Task 3: 切换到 per-cell（卡片列表版 + 重写 `_maybe_send_alert` + 删旧聚合函数）
+
+> 本 task 是一次原子切换：`build_feishu_card` 签名变更跨 notifier/scheduler 两个文件，必须同改才能保持测试绿。task 内 step 仍按 TDD 推进，中间态测试红是正常的，**只要 Step 11 提交时全绿**。
+
+**Files:**
+- Modify: `app/notifier.py`（`build_feishu_card` 改签名）
+- Modify: `app/scheduler.py`（重写 `_maybe_send_alert`，约 `scheduler.py:227-255`）
+- Modify: `app/db.py`（删除 `get_run_success_rate`，约 `db.py:846-866`）
+- Test: `tests/test_notifier.py`（改 2 个卡片测试）
+- Test: `tests/test_alert_scheduler.py`（整体重写）
+- Test: `tests/test_alert_db.py`（删 2 个旧测试 + 改顶部 import）
+
+- [ ] **Step 1: 改卡片测试为列表签名**
+
+把 `tests/test_notifier.py` 中 `test_alert_card_red_header` 和 `test_recover_card_green_header` 两个函数整体替换为：
+
+```python
+def test_alert_card_red_header():
+    card = build_feishu_card("alert", "主力渠道",
+                             [("OpenAI-A", "gpt-4o", 72.0), ("OpenAI-B", "claude", 65.0)],
+                             90, "2026-06-09 10:30")
+    assert card["msg_type"] == "interactive"
+    assert card["card"]["config"]["wide_screen_mode"] is True
+    assert card["card"]["header"]["template"] == "red"
+    assert "告警" in card["card"]["header"]["title"]["content"]
+    flat = str(card)
+    assert "OpenAI-A" in flat and "gpt-4o" in flat and "72.0%" in flat
+    assert "OpenAI-B" in flat and "claude" in flat and "65.0%" in flat
+    assert "90%" in flat
+
+
+def test_recover_card_green_header():
+    card = build_feishu_card("recover", "主力渠道",
+                             [("OpenAI-A", "gpt-4o", 95.0)], 90, "2026-06-09 10:30")
+    assert card["card"]["header"]["template"] == "green"
+    assert "恢复" in card["card"]["header"]["title"]["content"]
+    flat = str(card)
+    assert "OpenAI-A" in flat and "gpt-4o" in flat and "95.0%" in flat
+```
+
+- [ ] **Step 2: 跑卡片测试确认失败**
+
+Run: `python -m pytest tests/test_notifier.py -k card -v`
+Expected: FAIL（旧实现是单格 `profile`/`rate` 位置参数签名，传 list 会 TypeError 或断言失败）
+
+- [ ] **Step 3: 改 `build_feishu_card` 为列表版**
+
+把 `app/notifier.py` 的 `build_feishu_card` 整个函数替换为：
+
+```python
+def build_feishu_card(kind: str, task_name: str,
+                      cells: list, threshold: int, ts: str) -> dict:
+    """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
+    cells: [(profile, model, rate), ...] —— 本轮新翻转的格子。"""
+    if kind == "recover":
+        template, title, color = "green", "✅ 已恢复", "green"
+    else:
+        template, title, color = "red", "🔴 拨测告警", "red"
+    elements = [
+        {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},
+    ]
+    for profile, model, rate in cells:
+        elements.append({"tag": "div", "fields": [
+            {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
+            {"is_short": True, "text": {"tag": "lark_md", "content": f"**模型**\n{model}"}},
+            {"is_short": True, "text": {"tag": "lark_md",
+                "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
+        ]})
+    elements.append({"tag": "hr"})
+    elements.append({"tag": "note", "elements": [
+        {"tag": "lark_md", "content": f"阈值 {threshold}% · {ts} · AITokenPerf"}]})
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "config": {"wide_screen_mode": True},
+            "header": {"template": template,
+                       "title": {"tag": "plain_text", "content": title}},
+            "elements": elements,
+        },
+    }
+```
+
+- [ ] **Step 4: 跑卡片测试确认通过**
+
+Run: `python -m pytest tests/test_notifier.py -k card -v`
+Expected: 2 passed
+
+- [ ] **Step 5: 重写 scheduler 测试**
+
+把 `tests/test_alert_scheduler.py` **整个文件**替换为：
+
+```python
+import json
+
+import pytest
+
+from app import notifier, scheduler
+from app.db import (
+    create_scheduled_task, save_result, get_scheduled_task,
+    update_scheduled_task, create_notifier,
+)
+
+
+async def _seed_task(cells, alert_state=None, enabled=True, notifier_id=None):
+    """cells: [(profile, model, succ, tot)] 落 result 行（run-1）+ 建任务。
+    alert_state: dict 或 None（None=保持默认）。notifier_id: None=新建有效告警器。"""
+    if notifier_id is None:
+        notifier_id = await create_notifier(1, "g", "https://open.feishu.cn/x")
+    sid = await create_scheduled_task(
+        1, "t", ["SiteA"], {}, "interval", "300",
+        alert_notifier_id=notifier_id, alert_threshold=90, alert_enabled=enabled,
+    )
+    if alert_state is not None:
+        await update_scheduled_task(sid, alert_state=json.dumps(alert_state))
+    for i, (pf, model, succ, tot) in enumerate(cells):
+        await save_result(
+            user_id=1, test_id=f"r{i}", filename=f"r{i}.json", timestamp="20260609_120000",
+            config_json=json.dumps({"profile_name": pf, "model": model}),
+            summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
+        )
+    return sid
+
+
+def _collector():
+    sent = []
+    async def fake_send(url, payload, timeout=10.0):
+        sent.append(payload)
+        return True
+    return sent, fake_send
+
+
+@pytest.mark.asyncio
+async def test_per_cell_alert_only_failing_cell(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 2, 10), ("SiteA", "claude", 10, 10)])
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 1                       # 只发一条红卡
+    flat = str(sent[0])
+    assert "gpt-4o" in flat and "claude" not in flat
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "alerting"
+    assert states["SiteA"]["claude"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    # prev: gpt-4o 告警中、claude 正常；本轮 gpt-4o 恢复(100%)、claude 跌破(10%)
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 10, 10), ("SiteA", "claude", 1, 10)],
+        alert_state={"SiteA": {"gpt-4o": "alerting", "claude": "ok"}},
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 2
+    cards = {c["card"]["header"]["template"]: str(c) for c in sent}
+    assert "claude" in cards["red"] and "gpt-4o" not in cards["red"]
+    assert "gpt-4o" in cards["green"] and "claude" not in cards["green"]
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "ok"
+    assert states["SiteA"]["claude"] == "alerting"
+
+
+@pytest.mark.asyncio
+async def test_no_alert_when_all_ok(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 10, 10)])
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_no_alert(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], enabled=False)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_skips_when_notifier_id_zero(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=0)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_skips_when_notifier_missing(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=999999)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_no_results_no_alert(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([])   # 不造 result 行
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-empty"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_zero_total_cell_skipped_preserves_state(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    # gpt-4o 本轮 total=0（未发出），claude 正常；prev gpt-4o=alerting → 保留
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 0, 0), ("SiteA", "claude", 10, 10)],
+        alert_state={"SiteA": {"gpt-4o": "alerting"}},
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []                          # 无翻转
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "alerting"   # 保留旧态
+    assert states["SiteA"]["claude"] == "ok"
+```
+
+- [ ] **Step 6: 跑 scheduler 测试确认失败**
+
+Run: `python -m pytest tests/test_alert_scheduler.py -v`
+Expected: FAIL（`_maybe_send_alert` 仍是旧单格逻辑：用 `get_run_success_rate` + 旧 `build_feishu_card` 签名，断言不符 / 抛错）
+
+- [ ] **Step 7: 重写 `_maybe_send_alert`**
+
+把 `app/scheduler.py` 的 `_maybe_send_alert` 整个函数（约 227-255 行）替换为：
+
+```python
+async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
+    """按 (站点,模型) 格子聚合成功率，逐格状态翻转，聚合成红/绿卡发送。全程不抛。"""
+    from app.db import get_run_success_rate_by_cell, get_notifier
+    from app.notifier import (
+        evaluate_alert, build_feishu_card, send_webhook, _load_alert_states,
+    )
+
+    notifier_id = task_row.get("alert_notifier_id") or 0
+    if not task_row.get("alert_enabled") or not notifier_id:
+        return  # 未开启 或 未选告警器：不发、不报错
+    ntf = await get_notifier(notifier_id)
+    webhook = (ntf or {}).get("webhook", "").strip()
+    if not webhook:
+        log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
+        return
+
+    cells = await get_run_success_rate_by_cell(run_ids)
+    if not cells:
+        log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
+        return
+
+    threshold = int(task_row.get("alert_threshold") or 90)
+    prev = _load_alert_states(task_row.get("alert_state"))
+    new_states: dict = {}
+    alerts, recovers = [], []
+    for (profile, model), (succ, tot) in cells.items():
+        p_state = prev.get(profile, {}).get(model, "ok")
+        if tot == 0:                       # 没真发出请求 → 不评估、保留旧态
+            new_states.setdefault(profile, {})[model] = p_state
+            continue
+        rate = succ / tot * 100
+        n_state, action = evaluate_alert(p_state, rate, threshold)
+        new_states.setdefault(profile, {})[model] = n_state
+        if action == "alert":
+            alerts.append((profile, model, rate))
+        elif action == "recover":
+            recovers.append((profile, model, rate))
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    name = task_row.get("name", "")
+    if alerts:
+        await send_webhook(webhook, build_feishu_card("alert", name, alerts, threshold, ts))
+    if recovers:
+        await send_webhook(webhook, build_feishu_card("recover", name, recovers, threshold, ts))
+
+    if new_states != prev:
+        await update_scheduled_task(
+            task_id, alert_state=json.dumps(new_states, ensure_ascii=False))
+```
+
+> `app/scheduler.py` 顶部已 `import json`（line 5）与 `from datetime import datetime`（line 10），无需新增 import。
+
+- [ ] **Step 8: 跑 scheduler 测试确认通过**
+
+Run: `python -m pytest tests/test_alert_scheduler.py -v`
+Expected: 8 passed
+
+- [ ] **Step 9: 删除旧 `get_run_success_rate` 及其测试**
+
+1. 删除 `app/db.py` 中的 `get_run_success_rate` 函数（约 846-866 行，即 `async def get_run_success_rate(run_ids: list) -> tuple:` 整段，保留其后的 `get_run_success_rate_by_cell`）。
+2. 在 `tests/test_alert_db.py` 顶部 import 去掉 `get_run_success_rate`：
+
+```python
+from app.db import (
+    create_scheduled_task,
+    get_scheduled_task,
+    update_scheduled_task,
+    save_result,
+)
+```
+
+3. 删除 `tests/test_alert_db.py` 中 `test_get_run_success_rate_aggregates` 和 `test_get_run_success_rate_empty` 两个函数。
+
+- [ ] **Step 10: 跑全部告警相关测试确认通过**
+
+Run: `python -m pytest tests/test_alert_db.py tests/test_notifier.py tests/test_alert_scheduler.py -v`
+Expected: 全 passed（无 `get_run_success_rate` 残留引用报错）
+
+- [ ] **Step 11: 提交**
+
+```bash
+git add app/notifier.py app/scheduler.py app/db.py tests/test_notifier.py tests/test_alert_scheduler.py tests/test_alert_db.py
+git commit -m "feat: 告警按「站点×模型」逐格判定并聚合发卡 (#56)"
+```
+
+---
+
+## Task 4: 全量回归
+
+**Files:** 无代码改动，仅验证。
+
+- [ ] **Step 1: 跑整库测试**
+
+Run: `python -m pytest tests/ -q`
+Expected: 全 passed（重点确认 `tests/test_alert_api.py` 等未受影响 —— 本计划未碰 API/前端）。
+若有失败：定位是否因 `build_feishu_card` 签名或 `get_run_success_rate` 删除波及的其它引用，按报错修复后重跑。
+
+- [ ] **Step 2: 确认无遗留引用**
+
+Run: `grep -rn "get_run_success_rate\b" app/ tests/`
+Expected: 无输出（旧函数已彻底移除，新函数名为 `get_run_success_rate_by_cell` 不匹配 `\b` 边界后接 `(`）。
+注：若 grep 命中 `get_run_success_rate_by_cell`，属正常（用 `grep -rn "get_run_success_rate(" app/ tests/` 复查应无输出）。
+
+---
+
+## 自审记录（writing-plans self-review）
+
+**Spec 覆盖：**
+- §1 alert_state JSON 化 → Task 2（读）+ Task 3 Step 7（写 `json.dumps`）+ Step 9（列复用、无 DDL）。✓
+- §2 成功率分组 → Task 1。✓
+- §3 逐格判定 + 聚合 → Task 3 Step 7。✓（守卫、total=0 保留、`new!=prev` 才写、权衡保留）
+- §4 卡片列表版 → Task 3 Step 3。✓
+- §5 边界（total=0 / cells 空 / try-except 兜底）→ Task 3 测试 `test_zero_total_cell_skipped`/`test_no_results_no_alert`；`_run_scheduled_task` 末尾 try/except 未改动，保留。✓
+- §6 前端不动 → 计划无前端任务。✓
+- §7 测试策略 → Task 1/2/3 测试逐条对应；旧测试迁移/删除在 Task 3 Step 1/9。✓
+
+**占位扫描：** 无 TBD/TODO；每个改码 step 均含完整代码或精确删除指令。✓
+
+**类型/签名一致性：**
+- `get_run_success_rate_by_cell(run_ids) -> dict[(profile,model)->(s,t)]`：Task 1 定义，Task 3 Step 7 消费，键解构一致。✓
+- `build_feishu_card(kind, task_name, cells, threshold, ts)`：Task 3 Step 3 定义，Step 7 调用（`alerts`/`recovers` 均为 `[(profile,model,rate)]`）一致。✓
+- `_load_alert_states(raw) -> dict`：Task 2 定义，Task 3 Step 7 消费。✓
+- `alert_state` 写为 `json.dumps(dict)`，读为 `_load_alert_states` —— 往返一致。✓

--- a/docs/superpowers/specs/2026-06-09-per-cell-alerting-design.md
+++ b/docs/superpowers/specs/2026-06-09-per-cell-alerting-design.md
@@ -1,0 +1,185 @@
+# 拨测告警「按站点×模型」细分策略 · 设计文档
+
+> 日期：2026-06-09
+> 关联：issue #56；在 #30（告警闭环）/ #33（告警器解耦）之上的策略增强
+> 状态：设计已确认（方向/粒度/呈现/状态存储/阈值粒度均与用户对齐），待写 implementation plan
+
+---
+
+## 问题
+
+现有告警（#30/#33）触发口径是**任务级整体成功率**：`_maybe_send_alert`
+（`scheduler.py:227`）用 `get_run_success_rate(run_ids)`（`db.py:846`）把一轮**全部** result
+行的 `success_count/total_requests` 揉成**一个**总数，跌破任务阈值才发飞书。
+
+这带来**稀释漏报**：一个定时任务常绑多个站点（profile）、每站点测多个模型，一轮拨测其实是
+「站点 × 模型」的矩阵。某个模型/某个站点挂了，会被其他正常格子的好成绩稀释，整体成功率仍在
+阈值之上 → **该报没报**。这与产品近期「按模型看数据」的方向（切模型、按模型筛选趋势）也不一致。
+
+## 目标
+
+- 告警判定从「任务级整体」下沉到**每个「站点×模型」格子各自判断**，消除稀释漏报。
+- 同一轮多个格子同时翻转时，**聚合成一条飞书卡**（新告警一条红卡、新恢复一条绿卡），不刷屏。
+- 改动集中在后端策略层，**前端配置（开关/阈值/选告警器）与拨测主流程不动**。
+
+## 非目标（YAGNI）
+
+- 不做每模型/每站点单独阈值（阈值仍任务级共用一个）。
+- 不做延迟/质量维度触发（本轮只把**成功率**这一维度细分；延迟突增、质量下降留后续）。
+- 不做「连续 N 次才报」防抖（沿用单次跌破即翻转；以后要再加）。
+- 不做前端「格子告警状态」面板。
+- 不新建 `alert_states` 表（用 JSON 字段，见下）。
+- 不动通知渠道（仍飞书；多渠道是另一条线）。
+
+---
+
+## 核心决策（已与用户对齐）
+
+| 维度 | 决定 |
+|---|---|
+| 触发粒度 | 每个 **(站点 profile, 模型 model)** 格子独立判断 |
+| 成功率口径 | 按格子分组：该格子本轮**跨所有并发档**的 `success/total` 累加 |
+| 状态存储 | 复用 `scheduled_tasks.alert_state` 列（TEXT），值从单值改为 **JSON**：`{站点: {模型: 状态}}` |
+| 阈值粒度 | **任务级共用一个**（`alert_threshold`，默认 90），所有格子同一阈值 |
+| 判定逻辑 | 每格独立跑现有 `evaluate_alert`，**单次跌破即翻转**（不变） |
+| 告警呈现 | **聚合**：本轮新转告警的格子汇成一条红卡；新恢复的汇成一条绿卡；无翻转不发 |
+| 前端 | 不动（配置项语义不变） |
+
+---
+
+## 设计
+
+### 1. 数据模型：`alert_state` JSON 化（不新增表、不新增列）
+
+- 列定义不变：`scheduled_tasks.alert_state TEXT NOT NULL DEFAULT 'ok'`
+  （SQLite `db.py:123`、PG `db.py:233`、迁移 `db.py:339/351`）——**无需 DDL 改动**。
+- 值语义改变：由单值 `'ok'|'alerting'` → JSON 字符串，结构：
+  ```json
+  {"站点A": {"gpt-4o": "alerting", "claude": "ok"}, "站点B": {"gpt-4o": "ok"}}
+  ```
+- 写回白名单**已包含 `alert_state`**（`update_scheduled_task` 的 `allowed`，`db.py:1414`），
+  无需改动。
+- **读侧兼容**：新增纯函数 `_load_alert_states(raw) -> dict`：`json.loads`，若结果非 dict 或
+  解析失败（存量任务的裸值 `'ok'`/`'alerting'` 会 `JSONDecodeError`）→ 返回 `{}`。
+  存量任务首轮按当前格子重建，平滑过渡，无需数据迁移。
+- **自动清残留**：每轮写回时**只保留本轮真实出现的格子**。任务增删站点/模型后，旧格子的
+  key 自然不再带入 → 状态字典随当前矩阵收敛，不积累垃圾。
+
+### 2. 成功率分组（`app/db.py`）
+
+新增 DB 助手（旧 `get_run_success_rate` 仅 `scheduler.py:241` 一处调用，由新函数替代，
+连同其单测一并移除，避免死代码）：
+
+```python
+async def get_run_success_rate_by_cell(run_ids: list) -> dict[tuple[str, str], tuple[int, int]]:
+    """按 (profile_name, model) 分组聚合本轮 result 行的 (success, total)。"""
+```
+
+- SQL：`SELECT profile_name, config_json, summary_json FROM results WHERE run_id IN (...)`
+  （沿用现有占位符参数化写法，跨 SQLite/PG）。
+- 分组键：
+  - 站点 = `profile_name` 独立列（`db.py:313` 迁移已加）；为空时回退 `config_json.get("profile_name")`。
+  - 模型 = `json.loads(config_json).get("model")`（与 `db.py:1268/1716` 现有取法一致）；
+    缺失归为 `"-"`，仍计入但模型名显示 `-`。
+- 同一 (站点, 模型) 的多条并发档行累加，得该格子整体 success/total。
+- 在 **Python 端**解析 JSON 分组（不依赖 `jsonb` 操作符），保证双方言一致。
+
+### 3. 判定 + 聚合（重写 `scheduler._maybe_send_alert`，`scheduler.py:227-255`）
+
+```
+cells   = await get_run_success_rate_by_cell(run_ids)      # {(profile,model): (s,t)}
+prev    = _load_alert_states(task_row.get("alert_state"))  # {profile:{model:state}}
+thr     = int(task_row.get("alert_threshold") or 90)
+new     = {}                       # 本轮写回的状态字典（只含本轮格子）
+alerts, recovers = [], []          # 聚合：本轮新翻转的格子
+
+for (profile, model), (s, t) in cells.items():
+    p_state = prev.get(profile, {}).get(model, "ok")
+    if t == 0:                     # 没真发出请求（容量不足/跳过）→ 不评估、保留旧态
+        new.setdefault(profile, {})[model] = p_state
+        continue
+    rate = s / t * 100
+    n_state, action = evaluate_alert(p_state, rate, thr)   # 复用 notifier 现有纯函数
+    new.setdefault(profile, {})[model] = n_state
+    if action == "alert":   alerts.append((profile, model, rate))
+    elif action == "recover": recovers.append((profile, model, rate))
+```
+
+- 守卫照旧：`alert_enabled` 关 / `alert_notifier_id` 为 0 / 告警器查不到 webhook → 直接 return
+  （`scheduler.py:233-240` 逻辑保留）。
+- **发卡（聚合）**：`alerts` 非空 → 发一条红卡；`recovers` 非空 → 发一条绿卡。各最多一条。
+- **写回**：`new` 序列化 JSON → `update_scheduled_task(task_id, alert_state=...)`；仅当
+  `new != prev` 时写（省一次写）。
+- **权衡保留**：先发卡、无论推送成功失败都按判定写回新状态（单次推送失败 → 那次漏报，下次
+  翻转再发），不引入重试队列。与现状一致。
+- **多 worker 安全**：`claim_scheduled_task` 保证同任务每轮单 worker，JSON 读-改-写无并发，
+  与现状同构。
+
+### 4. 飞书卡片（改 `notifier.build_feishu_card`，`notifier.py:48`）
+
+现签名按单格设计：`build_feishu_card(kind, task_name, profile, rate, threshold, ts)`。
+改为吃**格子列表**：
+
+```python
+def build_feishu_card(kind: str, task_name: str,
+                      cells: list[tuple[str, str, float]],  # [(profile, model, rate), ...]
+                      threshold: int, ts: str) -> dict:
+```
+
+- 红卡（`kind='alert'`）：头部 `template:"red"`，标题「🔴 拨测告警」；正文逐行列每个掉线格子
+  `站点 / 模型 / 成功率`（红）；底部 note 标注 `阈值 {threshold}% · {ts} · AITokenPerf`。
+- 绿卡（`kind='recover'`）：头部 `template:"green"`，标题「✅ 已恢复」；逐行列恢复的格子。
+- 行用独立 `div`/`lark_md` 渲染，含 `config.wide_screen_mode`（沿用现有结构）。
+- `evaluate_alert` / `send_webhook` / `is_allowed_webhook` / `_safe_host` **不变**。
+- `scheduler.py:250` 的 `profiles_text` 拼接逻辑随之删除（卡片改逐格列）。
+
+### 5. 边界 & 安全
+
+- 某格 `total == 0`：不评估、保留旧态写回（见 §3），不把"没跑成"误判为成功/失败。
+- 全轮无任何格子（`cells` 空）：不发、不写回（或写空字典，等价）。
+- 告警评估整段仍由 `_run_scheduled_task` 末尾 try/except 兜底（`scheduler.py:389-393`），
+  坏了只 `log_error`，不拖累拨测与重调度。
+- SSRF（限飞书域名）、日志脱敏、best-effort 发送：**全部不变**。
+
+### 6. 前端
+
+**不动**。开关 `alert_enabled`、阈值 `alert_threshold`、告警器 `alert_notifier_id` 仍在任务级，
+表单与语义不变（`SiteSchedulesTab.vue` / `TasksView.vue` / 告警器管理页均无需改）。
+
+### 7. 测试策略
+
+- **`get_run_success_rate_by_cell`**：多站点 × 多模型 × 多并发档正确分组累加；`profile_name`
+  空回退 `config_json`；`model` 缺失归 `-`；空 run_ids 返回空。
+- **`_load_alert_states`**：合法 JSON 正常解析；存量裸值 `'ok'`/`'alerting'` → `{}`；空串 → `{}`。
+- **`_maybe_send_alert`（per-cell 聚合）**：
+  - A 格挂、B 格好 → 只 `alerts` 含 A，红卡仅 A；
+  - 同轮 A 恢复、B 挂 → 红卡含 B、绿卡含 A，各一条；
+  - 全好且原全好 → 不发、不写回；
+  - 某格 `total=0` → 跳过评估但保留旧态；
+  - 写回 JSON 结构正确、旧格子被剔除。
+- **`build_feishu_card`（列表版）**：红卡多行、绿卡多行、阈值/时间 note、`wide_screen_mode`。
+- **回归**：`evaluate_alert` 现有纯函数单测不变（仍逐格调用）。
+- 旧的 `build_feishu_card` 单格签名单测、`get_run_success_rate` 单测**迁移/移除**。
+- 不依赖真实网络（沿用 monkeypatch `send_webhook`）。
+
+---
+
+## 影响面
+
+- `app/db.py`：新增 `get_run_success_rate_by_cell`；移除旧 `get_run_success_rate`（仅一处引用）。
+  **无 DDL / 白名单改动**（`alert_state` 列与白名单复用）。
+- `app/scheduler.py`：重写 `_maybe_send_alert`（分组成功率 + 每格判定 + 聚合发卡 + JSON 状态
+  读写）；删 `profiles_text` 拼接。
+- `app/notifier.py`：`build_feishu_card` 改列表版 + 新增 `_load_alert_states`（或放 scheduler，
+  就近即可）。`evaluate_alert`/`send_webhook`/SSRF 不变。
+- 测试：`tests/test_alert_db.py` / `test_alert_scheduler.py` / `test_notifier.py` 相应增改。
+- 前端：**无**。
+
+## 向后兼容
+
+- `alert_state` 列复用，存量裸值读时兼容为 `{}`，存量任务首轮重建，无需数据迁移。
+- 阈值/开关/告警器语义不变，存量任务 `alert_enabled=false` 不受影响。
+
+---
+
+*实现前请对照当前代码复核 file:line（基于 2026-06-09 main）。*

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -7,7 +7,6 @@ from app.db import (
     get_scheduled_task,
     update_scheduled_task,
     save_result,
-    get_run_success_rate,
 )
 
 
@@ -26,23 +25,6 @@ async def test_update_alert_state_persists():
     await update_scheduled_task(sid, alert_state="alerting")
     row = await get_scheduled_task(sid)
     assert row["alert_state"] == "alerting"
-
-
-@pytest.mark.asyncio
-async def test_get_run_success_rate_aggregates():
-    for i, (succ, tot) in enumerate([(8, 10), (5, 10)]):
-        await save_result(
-            user_id=1, test_id=f"t{i}", filename=f"f{i}.json", timestamp="20260604_120000",
-            config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
-            percentiles_json="{}", run_id="run-x",
-        )
-    assert await get_run_success_rate(["run-x"]) == (13, 20)
-
-
-@pytest.mark.asyncio
-async def test_get_run_success_rate_empty():
-    assert await get_run_success_rate([]) == (0, 0)
-    assert await get_run_success_rate(["nope"]) == (0, 0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -151,3 +151,17 @@ async def test_success_rate_by_cell_empty():
     from app.db import get_run_success_rate_by_cell
     assert await get_run_success_rate_by_cell([]) == {}
     assert await get_run_success_rate_by_cell(["nope"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_blank_profile():
+    from app.db import get_run_success_rate_by_cell
+    # config_json 无 profile_name → profile_name 列写空 → 归 "-"
+    await save_result(
+        user_id=1, test_id="bp", filename="bp.json", timestamp="20260609_120000",
+        config_json=json.dumps({"model": "gpt-4o"}),
+        summary_json=json.dumps({"success_count": 7, "total_requests": 10}),
+        percentiles_json="{}", run_id="run-bp",
+    )
+    cells = await get_run_success_rate_by_cell(["run-bp"])
+    assert cells[("-", "gpt-4o")] == (7, 10)

--- a/tests/test_alert_db.py
+++ b/tests/test_alert_db.py
@@ -109,3 +109,45 @@ async def test_notifier_crud_and_delete_guard():
     ok2, refs2 = await delete_notifier(nid2)
     assert ok2 is False and refs2 == 1
     assert await get_notifier(nid2) is not None  # 没被删
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_groups():
+    from app.db import get_run_success_rate_by_cell
+    rows = [
+        ("SiteA", "gpt-4o", 8, 10),
+        ("SiteA", "gpt-4o", 9, 10),   # 同格第二并发档，应累加
+        ("SiteA", "claude", 5, 10),
+        ("SiteB", "gpt-4o", 10, 10),
+    ]
+    for i, (pf, model, succ, tot) in enumerate(rows):
+        await save_result(
+            user_id=1, test_id=f"c{i}", filename=f"c{i}.json", timestamp="20260609_120000",
+            config_json=json.dumps({"profile_name": pf, "model": model}),
+            summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-cell",
+        )
+    cells = await get_run_success_rate_by_cell(["run-cell"])
+    assert cells[("SiteA", "gpt-4o")] == (17, 20)
+    assert cells[("SiteA", "claude")] == (5, 10)
+    assert cells[("SiteB", "gpt-4o")] == (10, 10)
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_model_missing():
+    from app.db import get_run_success_rate_by_cell
+    await save_result(
+        user_id=1, test_id="nm", filename="nm.json", timestamp="20260609_120000",
+        config_json=json.dumps({"profile_name": "SiteA"}),  # 无 model
+        summary_json=json.dumps({"success_count": 3, "total_requests": 4}),
+        percentiles_json="{}", run_id="run-nm",
+    )
+    cells = await get_run_success_rate_by_cell(["run-nm"])
+    assert cells[("SiteA", "-")] == (3, 4)
+
+
+@pytest.mark.asyncio
+async def test_success_rate_by_cell_empty():
+    from app.db import get_run_success_rate_by_cell
+    assert await get_run_success_rate_by_cell([]) == {}
+    assert await get_run_success_rate_by_cell(["nope"]) == {}

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -3,131 +3,138 @@ import json
 import pytest
 
 from app import notifier, scheduler
-from app.db import create_scheduled_task, save_result, get_scheduled_task, update_scheduled_task, create_notifier
+from app.db import (
+    create_scheduled_task, save_result, get_scheduled_task,
+    update_scheduled_task, create_notifier,
+)
 
 
-async def _seed(rate_pair, alert_state="ok", enabled=True):
-    succ, tot = rate_pair
-    nid = await create_notifier(1, "g", "https://open.feishu.cn/x")
+async def _seed_task(cells, alert_state=None, enabled=True, notifier_id=None):
+    """cells: [(profile, model, succ, tot)] 落 result 行（run-1）+ 建任务。
+    alert_state: dict 或 None（None=保持默认）。notifier_id: None=新建有效告警器。"""
+    if notifier_id is None:
+        notifier_id = await create_notifier(1, "g", "https://open.feishu.cn/x")
     sid = await create_scheduled_task(
         1, "t", ["SiteA"], {}, "interval", "300",
-        alert_notifier_id=nid, alert_threshold=90, alert_enabled=enabled,
+        alert_notifier_id=notifier_id, alert_threshold=90, alert_enabled=enabled,
     )
-    if alert_state != "ok":
-        await update_scheduled_task(sid, alert_state=alert_state)
-    await save_result(
-        user_id=1, test_id="a", filename="a.json", timestamp="20260604_120000",
-        config_json="{}", summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
-        percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
-    )
+    if alert_state is not None:
+        await update_scheduled_task(sid, alert_state=json.dumps(alert_state))
+    for i, (pf, model, succ, tot) in enumerate(cells):
+        await save_result(
+            user_id=1, test_id=f"r{i}", filename=f"r{i}.json", timestamp="20260609_120000",
+            config_json=json.dumps({"profile_name": pf, "model": model}),
+            summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+            percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
+        )
     return sid
 
 
-@pytest.mark.asyncio
-async def test_alert_fires_and_writes_state(monkeypatch):
+def _collector():
     sent = []
     async def fake_send(url, payload, timeout=10.0):
-        sent.append(payload); return True
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+        sent.append(payload)
+        return True
+    return sent, fake_send
 
-    sid = await _seed((5, 10))  # 50% < 90%
+
+@pytest.mark.asyncio
+async def test_per_cell_alert_only_failing_cell(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 2, 10), ("SiteA", "claude", 10, 10)])
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
-
-    assert len(sent) == 1
-    assert (await get_scheduled_task(sid))["alert_state"] == "alerting"
+    assert len(sent) == 1                       # 只发一条红卡
+    flat = str(sent[0])
+    assert "gpt-4o" in flat and "claude" not in flat
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "alerting"
+    assert states["SiteA"]["claude"] == "ok"
 
 
 @pytest.mark.asyncio
-async def test_no_alert_when_disabled(monkeypatch):
-    sent = []
-    async def fake_send(url, payload, timeout=10.0):
-        sent.append(payload); return True
+async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
+    sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    # prev: gpt-4o 告警中、claude 正常；本轮 gpt-4o 恢复(100%)、claude 跌破(10%)
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 10, 10), ("SiteA", "claude", 1, 10)],
+        alert_state={"SiteA": {"gpt-4o": "alerting", "claude": "ok"}},
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 2
+    cards = {c["card"]["header"]["template"]: str(c) for c in sent}
+    assert "claude" in cards["red"] and "gpt-4o" not in cards["red"]
+    assert "gpt-4o" in cards["green"] and "claude" not in cards["green"]
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "ok"
+    assert states["SiteA"]["claude"] == "alerting"
 
-    sid = await _seed((5, 10), enabled=False)
+
+@pytest.mark.asyncio
+async def test_no_alert_when_all_ok(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 10, 10)])
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
     assert sent == []
 
 
 @pytest.mark.asyncio
-async def test_no_alert_when_no_results(monkeypatch):
-    # 本轮无有效请求（run_ids 无对应 result 行）→ total==0，跳过评估、不发、不改状态
-    sent = []
-    async def fake_send(url, payload, timeout=10.0):
-        sent.append(payload); return True
+async def test_disabled_no_alert(monkeypatch):
+    sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], enabled=False)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
 
-    nid = await create_notifier(1, "g", "https://open.feishu.cn/x")
-    sid = await create_scheduled_task(
-        1, "t", ["SiteA"], {}, "interval", "300",
-        alert_notifier_id=nid, alert_threshold=90, alert_enabled=True,
-    )
+
+@pytest.mark.asyncio
+async def test_skips_when_notifier_id_zero(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=0)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_skips_when_notifier_missing(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=999999)
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_no_results_no_alert(monkeypatch):
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([])   # 不造 result 行
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-empty"])
     assert sent == []
-    assert (await get_scheduled_task(sid))["alert_state"] == "ok"
 
 
 @pytest.mark.asyncio
-async def test_recover_when_back_to_normal(monkeypatch):
-    sent = []
-    async def fake_send(url, payload, timeout=10.0):
-        sent.append(payload); return True
+async def test_zero_total_cell_skipped_preserves_state(monkeypatch):
+    sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-
-    sid = await _seed((10, 10), alert_state="alerting")  # 100% >= 90%, 之前告警中
+    # gpt-4o 本轮 total=0（未发出），claude 正常；prev gpt-4o=alerting → 保留
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 0, 0), ("SiteA", "claude", 10, 10)],
+        alert_state={"SiteA": {"gpt-4o": "alerting"}},
+    )
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert len(sent) == 1
-    assert (await get_scheduled_task(sid))["alert_state"] == "ok"
-
-
-@pytest.mark.asyncio
-async def test_alert_uses_notifier_webhook(monkeypatch):
-    sent = {}
-    async def fake_send(url, payload, timeout=10.0):
-        sent["url"] = url
-        return True
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed((0, 10))  # 0% < 90% 必触发
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert sent.get("url") == "https://open.feishu.cn/x"
-
-
-@pytest.mark.asyncio
-async def test_alert_skips_when_no_notifier(monkeypatch):
-    sent = []
-    async def fake_send(url, payload, timeout=10.0):
-        sent.append(url)
-        return True
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # alert_enabled 但没选告警器（notifier_id=0）→ 不发
-    sid = await create_scheduled_task(1, "tn", ["SiteA"], {}, "interval", "300",
-                                      alert_notifier_id=0, alert_threshold=90, alert_enabled=True)
-    await save_result(user_id=1, test_id="b", filename="b.json", timestamp="20260604_120000",
-                      config_json="{}", summary_json=json.dumps({"success_count": 0, "total_requests": 10}),
-                      percentiles_json="{}", run_id="run-2", scheduled_task_id=sid)
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-2"])
-    assert sent == []
-
-
-@pytest.mark.asyncio
-async def test_alert_skips_when_notifier_missing(monkeypatch):
-    sent = []
-    async def fake_send(url, payload, timeout=10.0):
-        sent.append(url)
-        return True
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # 指向一个不存在的告警器 id（如被删）→ 安全跳过
-    sid = await create_scheduled_task(1, "tm", ["SiteA"], {}, "interval", "300",
-                                      alert_notifier_id=999999, alert_threshold=90, alert_enabled=True)
-    await save_result(user_id=1, test_id="c", filename="c.json", timestamp="20260604_120000",
-                      config_json="{}", summary_json=json.dumps({"success_count": 0, "total_requests": 10}),
-                      percentiles_json="{}", run_id="run-3", scheduled_task_id=sid)
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-3"])
-    assert sent == []
+    assert sent == []                          # 无翻转
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == "alerting"   # 保留旧态
+    assert states["SiteA"]["claude"] == "ok"

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -101,3 +101,27 @@ async def test_send_webhook_non_2xx_returns_false(monkeypatch):
         def post(self, *a, **k): return FakeResp()
     monkeypatch.setattr(notifier.aiohttp, "ClientSession", FakeSession)
     assert await notifier.send_webhook("https://open.feishu.cn/x", {"a": 1}) is False
+
+
+def test_load_alert_states_valid_json():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states('{"SiteA": {"gpt-4o": "alerting"}}') == {"SiteA": {"gpt-4o": "alerting"}}
+
+
+def test_load_alert_states_legacy_scalar():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states("ok") == {}
+    assert _load_alert_states("alerting") == {}
+
+
+def test_load_alert_states_empty_or_none():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states("") == {}
+    assert _load_alert_states(None) == {}
+
+
+def test_load_alert_states_non_dict_json():
+    from app.notifier import _load_alert_states
+    assert _load_alert_states('"ok"') == {}
+    assert _load_alert_states("123") == {}
+    assert _load_alert_states("[1, 2]") == {}

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -53,19 +53,26 @@ def test_empty_rejected():
 
 
 def test_alert_card_red_header():
-    card = build_feishu_card("alert", "主力渠道", "OpenAI-A", 72.0, 90, "2026-06-04 10:30")
+    card = build_feishu_card("alert", "主力渠道",
+                             [("OpenAI-A", "gpt-4o", 72.0), ("OpenAI-B", "claude", 65.0)],
+                             90, "2026-06-09 10:30")
     assert card["msg_type"] == "interactive"
     assert card["card"]["config"]["wide_screen_mode"] is True
     assert card["card"]["header"]["template"] == "red"
     assert "告警" in card["card"]["header"]["title"]["content"]
     flat = str(card)
-    assert "72.0%" in flat and "90%" in flat and "主力渠道" in flat
+    assert "OpenAI-A" in flat and "gpt-4o" in flat and "72.0%" in flat
+    assert "OpenAI-B" in flat and "claude" in flat and "65.0%" in flat
+    assert "90%" in flat
 
 
 def test_recover_card_green_header():
-    card = build_feishu_card("recover", "主力渠道", "OpenAI-A", 95.0, 90, "2026-06-04 10:30")
+    card = build_feishu_card("recover", "主力渠道",
+                             [("OpenAI-A", "gpt-4o", 95.0)], 90, "2026-06-09 10:30")
     assert card["card"]["header"]["template"] == "green"
     assert "恢复" in card["card"]["header"]["title"]["content"]
+    flat = str(card)
+    assert "OpenAI-A" in flat and "gpt-4o" in flat and "95.0%" in flat
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 告警判定从「任务级整体成功率」下沉到「每个 (站点, 模型) 格子」逐格判定，消除多站点/多模型任务里的稀释漏报
- 同一轮多格翻转时聚合成一条红卡（新告警）+ 一条绿卡（新恢复），不刷屏
- `alert_state` 列复用、改存 JSON（旧裸值自动兼容），**零 DDL / 零数据迁移**；前端与拨测主流程不动

## 实现
- `app/db.py`：新增 `get_run_success_rate_by_cell`（按 profile_name+model 分组），删旧 `get_run_success_rate`
- `app/notifier.py`：`_load_alert_states`（JSON 兼容读取）+ `build_feishu_card` 改聚合列表版
- `app/scheduler.py`：重写 `_maybe_send_alert`（逐格判定 + 聚合发卡 + JSON 状态读写）
- `app/server.py`：notifier 测试端点适配新签名

## 设计 / 计划
- `docs/superpowers/specs/2026-06-09-per-cell-alerting-design.md`
- `docs/superpowers/plans/2026-06-09-per-cell-alerting.md`

## Test plan
- [x] `test_alert_db` / `test_notifier` / `test_alert_scheduler` / `test_alert_api` 共 48 passed
- [x] 逐格场景：仅失败格告警、同轮一红一绿、`total=0` 保留旧态、空轮不发、告警器缺失/未选安全跳过
- [ ] （合并前可选）真机飞书验证聚合卡渲染

> 注：整库另有 4 个 `test_tab_refactor` 失败为 pre-existing 前端遗留（main 同样失败、本 PR 未碰前端），与本 PR 无关。

Closes #56