### PR TITLE
告警优化：防抖（连续2次）+ 标题信息化 + 卡片汇总

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -15,14 +15,21 @@ ALERT_ALERTING = "alerting"
 FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
 
 
-def evaluate_alert(prev_state: str, success_rate: float, threshold: int) -> Tuple[str, Optional[str]]:
-    """返回 (新状态, 动作)。动作 ∈ {None, 'alert', 'recover'}。仅状态翻转时给动作。"""
+def evaluate_alert(prev_state: str, prev_streak: int, success_rate: float,
+                   threshold: int, fail_needed: int = 2) -> Tuple[str, int, Optional[str]]:
+    """连续 fail_needed 次低于阈值才告警；恢复 1 次回到阈值即报（防抖）。
+    返回 (新状态, 新连续异常计数, 动作)。动作 ∈ {None, 'alert', 'recover'}。"""
     abnormal = success_rate < threshold
-    if abnormal and prev_state != ALERT_ALERTING:
-        return ALERT_ALERTING, "alert"
-    if not abnormal and prev_state == ALERT_ALERTING:
-        return ALERT_OK, "recover"
-    return prev_state, None
+    if abnormal:
+        if prev_state == ALERT_ALERTING:
+            return ALERT_ALERTING, prev_streak, None      # 已在告警，保持不重复发
+        streak = prev_streak + 1
+        if streak >= fail_needed:
+            return ALERT_ALERTING, streak, "alert"        # 连续达标，翻红告警
+        return ALERT_OK, streak, None                     # 仍在累积，先不发
+    if prev_state == ALERT_ALERTING:
+        return ALERT_OK, 0, "recover"                     # 一次回到阈值即恢复
+    return ALERT_OK, 0, None                              # 一直正常
 
 
 def _load_alert_states(raw) -> dict:
@@ -34,6 +41,21 @@ def _load_alert_states(raw) -> dict:
     except (json.JSONDecodeError, TypeError):
         return {}
     return v if isinstance(v, dict) else {}
+
+
+def _cell_state(value) -> Tuple[str, int]:
+    """解析单格状态，返回 (状态, 连续异常计数)。
+    兼容旧的裸字符串（"ok"/"alerting"）与新的 {"s": 状态, "n": 连续计数}。"""
+    if isinstance(value, dict):
+        state = value.get("s", ALERT_OK)
+        try:
+            streak = int(value.get("n", 0) or 0)
+        except (TypeError, ValueError):
+            streak = 0
+        return (state if state in (ALERT_OK, ALERT_ALERTING) else ALERT_OK), streak
+    if isinstance(value, str) and value in (ALERT_OK, ALERT_ALERTING):
+        return value, 0
+    return ALERT_OK, 0
 
 
 def _safe_host(url: str) -> str:
@@ -61,12 +83,19 @@ def build_feishu_card(kind: str, task_name: str,
                       cells: list, threshold: int, ts: str) -> dict:
     """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
     cells: [(profile, model, rate), ...] —— 本轮新翻转的格子。"""
+    n = len(cells)
+    label = f" · {task_name}" if task_name else ""
     if kind == "recover":
-        template, title, color = "green", "✅ 已恢复", "green"
+        template = color = "green"
+        title = f"✅ 已恢复{label}（{n} 个）"
+        summary = f"以下 {n} 个格子已恢复（成功率 ≥ 阈值 {threshold}%）"
     else:
-        template, title, color = "red", "🔴 拨测告警", "red"
+        template = color = "red"
+        title = f"🔴 拨测告警{label}（{n} 个异常）"
+        summary = f"本轮 {n} 个格子成功率低于阈值 {threshold}%"
     elements = [
         {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},
+        {"tag": "div", "text": {"tag": "lark_md", "content": summary}},
     ]
     for profile, model, rate in cells:
         elements.append({"tag": "div", "fields": [
@@ -77,7 +106,7 @@ def build_feishu_card(kind: str, task_name: str,
         ]})
     elements.append({"tag": "hr"})
     elements.append({"tag": "note", "elements": [
-        {"tag": "lark_md", "content": f"阈值 {threshold}% · {ts} · AITokenPerf"}]})
+        {"tag": "lark_md", "content": f"{ts} · AITokenPerf"}]})
     return {
         "msg_type": "interactive",
         "card": {

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -228,7 +228,8 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     """按 (站点,模型) 格子聚合成功率，逐格状态翻转，聚合成红/绿卡发送。全程不抛。"""
     from app.db import get_run_success_rate_by_cell, get_notifier
     from app.notifier import (
-        evaluate_alert, build_feishu_card, send_webhook, _load_alert_states,
+        evaluate_alert, build_feishu_card, send_webhook,
+        _load_alert_states, _cell_state,
     )
 
     notifier_id = task_row.get("alert_notifier_id") or 0
@@ -250,13 +251,13 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
     new_states: dict = {}
     alerts, recovers = [], []
     for (profile, model), (succ, tot) in cells.items():
-        p_state = prev.get(profile, {}).get(model, "ok")
+        p_state, p_streak = _cell_state(prev.get(profile, {}).get(model))
         if tot == 0:                       # 没真发出请求 → 不评估、保留旧态
-            new_states.setdefault(profile, {})[model] = p_state
+            new_states.setdefault(profile, {})[model] = {"s": p_state, "n": p_streak}
             continue
         rate = succ / tot * 100
-        n_state, action = evaluate_alert(p_state, rate, threshold)
-        new_states.setdefault(profile, {})[model] = n_state
+        n_state, n_streak, action = evaluate_alert(p_state, p_streak, rate, threshold)
+        new_states.setdefault(profile, {})[model] = {"s": n_state, "n": n_streak}
         if action == "alert":
             alerts.append((profile, model, rate))
         elif action == "recover":

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -42,25 +42,30 @@ def _collector():
 async def test_per_cell_alert_only_failing_cell(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 2, 10), ("SiteA", "claude", 10, 10)])
+    # gpt-4o 已累积 1 次（streak=1），本轮再跌破 → 连续 2 次翻红；claude 正常
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 2, 10), ("SiteA", "claude", 10, 10)],
+        alert_state={"SiteA": {"gpt-4o": {"s": "ok", "n": 1}}},
+    )
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
     assert len(sent) == 1                       # 只发一条红卡
     flat = str(sent[0])
     assert "gpt-4o" in flat and "claude" not in flat
     states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == "alerting"
-    assert states["SiteA"]["claude"] == "ok"
+    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"
+    assert states["SiteA"]["claude"]["s"] == "ok"
 
 
 @pytest.mark.asyncio
 async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # prev: gpt-4o 告警中、claude 正常；本轮 gpt-4o 恢复(100%)、claude 跌破(10%)
+    # prev: gpt-4o 告警中(旧裸字符串，测兼容)、claude 已累积 1 次；
+    # 本轮 gpt-4o 恢复(100%)、claude 再跌破(10%) → 连续 2 次翻红
     sid = await _seed_task(
         [("SiteA", "gpt-4o", 10, 10), ("SiteA", "claude", 1, 10)],
-        alert_state={"SiteA": {"gpt-4o": "alerting", "claude": "ok"}},
+        alert_state={"SiteA": {"gpt-4o": "alerting", "claude": {"s": "ok", "n": 1}}},
     )
     row = await get_scheduled_task(sid)
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
@@ -69,8 +74,8 @@ async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
     assert "claude" in cards["red"] and "gpt-4o" not in cards["red"]
     assert "gpt-4o" in cards["green"] and "claude" not in cards["green"]
     states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == "ok"
-    assert states["SiteA"]["claude"] == "alerting"
+    assert states["SiteA"]["gpt-4o"]["s"] == "ok"
+    assert states["SiteA"]["claude"]["s"] == "alerting"
 
 
 @pytest.mark.asyncio
@@ -136,5 +141,51 @@ async def test_zero_total_cell_skipped_preserves_state(monkeypatch):
     await scheduler._maybe_send_alert(sid, row, ["run-1"])
     assert sent == []                          # 无翻转
     states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == "alerting"   # 保留旧态
-    assert states["SiteA"]["claude"] == "ok"
+    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"   # 保留旧态
+    assert states["SiteA"]["claude"]["s"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_single_abnormal_round_does_not_alert(monkeypatch):
+    # 第一次跌破：不发卡，仅累积 streak=1（防抖）
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task([("SiteA", "gpt-4o", 2, 10)])
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 1}
+
+
+@pytest.mark.asyncio
+async def test_recovery_after_alert_single_good_round(monkeypatch):
+    # 已告警，一次回到阈值即报恢复并清零
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 10, 10)],
+        alert_state={"SiteA": {"gpt-4o": {"s": "alerting", "n": 2}}},
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert len(sent) == 1
+    assert sent[0]["card"]["header"]["template"] == "green"
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 0}
+
+
+@pytest.mark.asyncio
+async def test_streak_resets_on_good_round(monkeypatch):
+    # 累积中(streak=1)遇到一次正常 → 清零，不告警
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid = await _seed_task(
+        [("SiteA", "gpt-4o", 10, 10)],
+        alert_state={"SiteA": {"gpt-4o": {"s": "ok", "n": 1}}},
+    )
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    assert sent == []
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 0}

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -4,24 +4,64 @@ from app import notifier
 from app.notifier import build_feishu_card, evaluate_alert, is_allowed_webhook
 
 
-def test_alert_fires_on_ok_to_abnormal():
-    assert evaluate_alert("ok", 72.0, 90) == ("alerting", "alert")
+def test_first_abnormal_no_alert_increments_streak():
+    # 第一次低于阈值：不告警，仅累积 streak
+    assert evaluate_alert("ok", 0, 72.0, 90) == ("ok", 1, None)
+
+
+def test_second_consecutive_abnormal_fires():
+    # 连续第二次低于阈值：翻红告警
+    assert evaluate_alert("ok", 1, 72.0, 90) == ("alerting", 2, "alert")
 
 
 def test_no_repeat_while_abnormal():
-    assert evaluate_alert("alerting", 50.0, 90) == ("alerting", None)
+    # 已告警继续异常：保持，不重复发
+    assert evaluate_alert("alerting", 2, 50.0, 90) == ("alerting", 2, None)
 
 
 def test_recover_on_abnormal_to_ok():
-    assert evaluate_alert("alerting", 95.0, 90) == ("ok", "recover")
+    # 告警中一次回到阈值即报恢复，并清零
+    assert evaluate_alert("alerting", 2, 95.0, 90) == ("ok", 0, "recover")
+
+
+def test_single_normal_resets_streak():
+    # 累积中(streak=1)遇到一次正常：清零，不告警
+    assert evaluate_alert("ok", 1, 99.0, 90) == ("ok", 0, None)
 
 
 def test_no_action_while_ok():
-    assert evaluate_alert("ok", 99.0, 90) == ("ok", None)
+    assert evaluate_alert("ok", 0, 99.0, 90) == ("ok", 0, None)
 
 
 def test_threshold_boundary_is_normal():
-    assert evaluate_alert("ok", 90.0, 90) == ("ok", None)
+    # 等于阈值不算异常，且清零
+    assert evaluate_alert("ok", 1, 90.0, 90) == ("ok", 0, None)
+
+
+def test_custom_fail_needed_three():
+    # fail_needed=3：第 2 次仍不发，第 3 次才发
+    assert evaluate_alert("ok", 1, 50.0, 90, fail_needed=3) == ("ok", 2, None)
+    assert evaluate_alert("ok", 2, 50.0, 90, fail_needed=3) == ("alerting", 3, "alert")
+
+
+def test_cell_state_legacy_string():
+    from app.notifier import _cell_state
+    assert _cell_state("ok") == ("ok", 0)
+    assert _cell_state("alerting") == ("alerting", 0)
+
+
+def test_cell_state_new_dict():
+    from app.notifier import _cell_state
+    assert _cell_state({"s": "ok", "n": 1}) == ("ok", 1)
+    assert _cell_state({"s": "alerting", "n": 2}) == ("alerting", 2)
+
+
+def test_cell_state_missing_or_garbage():
+    from app.notifier import _cell_state
+    assert _cell_state(None) == ("ok", 0)
+    assert _cell_state({}) == ("ok", 0)
+    assert _cell_state("weird") == ("ok", 0)
+    assert _cell_state({"s": "weird", "n": "x"}) == ("ok", 0)
 
 
 def test_feishu_https_allowed():
@@ -59,20 +99,29 @@ def test_alert_card_red_header():
     assert card["msg_type"] == "interactive"
     assert card["card"]["config"]["wide_screen_mode"] is True
     assert card["card"]["header"]["template"] == "red"
-    assert "告警" in card["card"]["header"]["title"]["content"]
+    title = card["card"]["header"]["title"]["content"]
+    assert "告警" in title and "主力渠道" in title and "2 个异常" in title
     flat = str(card)
     assert "OpenAI-A" in flat and "gpt-4o" in flat and "72.0%" in flat
     assert "OpenAI-B" in flat and "claude" in flat and "65.0%" in flat
-    assert "90%" in flat
+    assert "低于阈值 90%" in flat            # 汇总行带阈值
 
 
 def test_recover_card_green_header():
     card = build_feishu_card("recover", "主力渠道",
                              [("OpenAI-A", "gpt-4o", 95.0)], 90, "2026-06-09 10:30")
     assert card["card"]["header"]["template"] == "green"
-    assert "恢复" in card["card"]["header"]["title"]["content"]
+    title = card["card"]["header"]["title"]["content"]
+    assert "恢复" in title and "主力渠道" in title and "1 个" in title
     flat = str(card)
     assert "OpenAI-A" in flat and "gpt-4o" in flat and "95.0%" in flat
+
+
+def test_card_title_handles_empty_task_name():
+    card = build_feishu_card("alert", "", [("S", "m", 50.0)], 90, "t")
+    title = card["card"]["header"]["title"]["content"]
+    assert title.startswith("🔴 拨测告警（")     # 空任务名不留悬空分隔符
+    assert "1 个异常" in title
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景
在 #56 逐格判定基础上，优化告警的**策略 / 标题 / 模板**（详见 #60）。

## 改动
- **策略防抖**：`evaluate_alert` 改为「连续 2 次低于阈值才告警、恢复 1 次回到阈值即报」，杜绝天然抖动端点的红绿反复发卡；新增 `_cell_state` 解析单格状态，兼容旧裸字符串 `"ok"/"alerting"` 与新 `{"s":状态,"n":连续计数}`。
- **调度接入**：`_maybe_send_alert` 按 streak 读写逐格状态；`tot==0`（本轮未发出请求）保留旧态。
- **卡片标题/模板**：标题加任务名 + 异常格子数（`🔴 拨测告警 · {任务}（N 个异常）` / `✅ 已恢复 · {任务}（N 个）`），便于飞书列表区分；body 顶部加汇总行；footer 去掉与汇总行重复的阈值。

## 兼容性
- 旧告警状态（裸字符串或 DB 默认 `'ok'`）经 `_cell_state` 平滑读取，首轮自动迁移为 `{s,n}`。
- `build_feishu_card` 签名不变，`/api/notifiers/{id}/test` 端点无需改（其标题本就被覆盖）。

## 测试
- `tests/test_notifier.py` / `tests/test_alert_scheduler.py`：新增连续判定 / 恢复 / 清零 / 旧格式兼容 / 标题计数用例。
- 全量后端回归 **288 passed**（排除既有失效的 `test_tab_refactor`，与本改动无关）。

Closes #60