### PR TITLE
本地开发后端默认端口 8080 → 8420

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python3 main.py
 需要 [bun](https://bun.sh/) 来构建前端。
 
 ```bash
-# 同时启动后端 (8080) + 前端 Dev Server (5180)
+# 同时启动后端 (8420) + 前端 Dev Server (5180)
 ./start.sh
 
 # 单独构建前端（输出到 static/）
@@ -83,7 +83,7 @@ python3 main.py [--port PORT] [--host HOST] [--workers N]
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `--port` | 8080 | Web 服务端口 |
+| `--port` | 8420 | Web 服务端口 |
 | `--host` | 127.0.0.1 | 绑定地址，设为 `0.0.0.0` 可对外访问 |
 | `--workers` | 1 | Worker 进程数 |
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       '/api': {
-        target: process.env.VITE_PROXY_TARGET || 'http://localhost:8080',
+        target: process.env.VITE_PROXY_TARGET || 'http://localhost:8420',
         changeOrigin: true,
       },
     },

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 AITokenPerf — API SSE 流式压测工具 (Web 模式)
 
 用法:
-  python3 main.py                    # 默认 8080 端口
+  python3 main.py                    # 默认 8420 端口
   python3 main.py --port 9000        # 指定端口
 """
 
@@ -125,7 +125,7 @@ async def run_dry(session: aiohttp.ClientSession, config: dict):
 
 def main():
     parser = argparse.ArgumentParser(description="AITokenPerf — API 压测工具 (Web 模式)")
-    parser.add_argument("--port", type=int, default=8080, help="Web 服务端口 (默认 8080)")
+    parser.add_argument("--port", type=int, default=8420, help="Web 服务端口 (默认 8420)")
     parser.add_argument("--host", type=str, default=os.environ.get("HOST", "127.0.0.1"), help="绑定地址 (默认 127.0.0.1)")
     parser.add_argument("--workers", type=int, default=1, help="Worker 进程数 (默认 1)")
     args = parser.parse_args()

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 一键启动前端(Vite dev) + 后端(Python)
 # 前端 http://localhost:5180 (含 HMR)
-# 后端 http://localhost:8080
+# 后端 http://localhost:8420
 
 set -e
 cd "$(dirname "$0")"
@@ -20,7 +20,7 @@ trap "kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit" SIGINT SIGTERM
 
 echo ""
 echo "前端: http://localhost:5180"
-echo "后端: http://localhost:8080"
+echo "后端: http://localhost:8420"
 echo ""
 
 wait


### PR DESCRIPTION
本地开发默认后端端口 `8080` 太通用、易与本机其他服务冲突，改为 **8420**。

## 改动（仅本地开发默认）
- `main.py`：`--port` 默认 8080 → 8420（含用法注释 + help 文本）
- `frontend/vite.config.js`：dev 代理 target 默认 → `http://localhost:8420`（仍保留 `VITE_PROXY_TARGET` 覆盖）
- `README.md`：开发模式说明 + `--port` 默认表
- `start.sh`：启动提示文字

## 不动（部署维持 8080）
- `Dockerfile`（EXPOSE/CMD）、`docker-compose*.yml` 端口映射、README 的 docker 访问说明
- 线上经反向代理走 443，内部 8080 不受影响，零线上风险、不碰 nginx

## 验证
- `main.py --help` 显示 `--port` 默认 8420，解析正常。

Closes #62