### PR TITLE
fix: 任务名留空时默认按站点命名 (#65)

### DIFF
--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -61,7 +61,7 @@
         <div class="form-grid" style="margin-top:12px">
           <div class="form-group">
             <label class="form-label">任务名称</label>
-            <input class="form-input" v-model="createForm.name" placeholder="留空将自动生成（持续监控-模型名）">
+            <input class="form-input" v-model="createForm.name" placeholder="留空将自动生成（持续监控-站点名）">
           </div>
           <div class="form-group">
             <label class="form-label">并发数</label>
@@ -606,9 +606,9 @@ async function createSchedule() {
     toast('请至少选择一个模型', 'info');
     return;
   }
-  // 任务名留空时自动生成（任务名已折叠进高级参数，多数用户不填）
+  // 任务名留空时自动按站点命名（一个站点会测多个模型，不取单个模型名）
   if (!f.name.trim()) {
-    f.name = `持续监控-${f.models[0]}`;
+    f.name = `持续监控-${props.profile.name}`;
   }
 
   createLoading.value = true;


### PR DESCRIPTION
## Summary
- 创建拨测任务时，任务名留空的自动命名由 `持续监控-{第一个模型}` 改为 `持续监控-{站点名}`（`props.profile.name`）
- 一个站点会对多个模型拨测，按单个模型命名会误导；改用站点名更贴合
- 输入框 placeholder 同步更新为「留空将自动生成（持续监控-站点名）」

Closes #65

## Test plan
- [x] `vite build` 通过
- [x] 前端 vitest 全绿（43/43）
- [ ] 浏览器中目测：站点页创建任务、任务名留空提交后名称为「持续监控-站点名」