### PR TITLE
feat: 飞书告警标题加入首个站点×模型 (#66)

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -84,14 +84,15 @@ def build_feishu_card(kind: str, task_name: str,
     """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
     cells: [(profile, model, rate), ...] —— 本轮新翻转的格子。"""
     n = len(cells)
+    cell = f" · {cells[0][0]}/{cells[0][1]}" if cells else ""  # 首个异常的站点/模型，手机一眼定位
     label = f" · {task_name}" if task_name else ""
     if kind == "recover":
         template = color = "green"
-        title = f"✅ 已恢复{label}（{n} 个）"
+        title = f"✅ 已恢复{cell}{label}（{n} 个）"
         summary = f"以下 {n} 个格子已恢复（成功率 ≥ 阈值 {threshold}%）"
     else:
         template = color = "red"
-        title = f"🔴 拨测告警{label}（{n} 个异常）"
+        title = f"🔴 拨测告警{cell}{label}（{n} 个异常）"
         summary = f"本轮 {n} 个格子成功率低于阈值 {threshold}%"
     elements = [
         {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -101,6 +101,7 @@ def test_alert_card_red_header():
     assert card["card"]["header"]["template"] == "red"
     title = card["card"]["header"]["title"]["content"]
     assert "告警" in title and "主力渠道" in title and "2 个异常" in title
+    assert "OpenAI-A/gpt-4o" in title          # 首个异常的站点×模型进标题
     flat = str(card)
     assert "OpenAI-A" in flat and "gpt-4o" in flat and "72.0%" in flat
     assert "OpenAI-B" in flat and "claude" in flat and "65.0%" in flat
@@ -113,6 +114,7 @@ def test_recover_card_green_header():
     assert card["card"]["header"]["template"] == "green"
     title = card["card"]["header"]["title"]["content"]
     assert "恢复" in title and "主力渠道" in title and "1 个" in title
+    assert "OpenAI-A/gpt-4o" in title
     flat = str(card)
     assert "OpenAI-A" in flat and "gpt-4o" in flat and "95.0%" in flat
 
@@ -120,8 +122,9 @@ def test_recover_card_green_header():
 def test_card_title_handles_empty_task_name():
     card = build_feishu_card("alert", "", [("S", "m", 50.0)], 90, "t")
     title = card["card"]["header"]["title"]["content"]
-    assert title.startswith("🔴 拨测告警（")     # 空任务名不留悬空分隔符
+    assert title.startswith("🔴 拨测告警 · S/m")   # 站点×模型进标题
     assert "1 个异常" in title
+    assert " ·  · " not in title                   # 空任务名不留悬空分隔符
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 飞书卡片标题在原「🔴 拨测告警 · {任务名}（N 个异常）」基础上，最前面加入首个异常的「站点/模型」
- 新格式：`🔴 拨测告警 · OpenAI-A/gpt-4o · 主力渠道（2 个异常）`、恢复同理 `✅ 已恢复 · OpenAI-A/gpt-4o · 主力渠道（1 个）`
- 站点×模型紧跟告警词，手机通知一眼定位故障点；任务名与计数保留；空任务名不留悬空分隔符
- 更新/补充 notifier 标题相关测试

Closes #66

## Test plan
- [x] `pytest tests/test_notifier.py tests/test_schedule_notify.py` 全绿（29）
- [x] `py_compile app/*.py` 通过
- [x] TDD：先改测试见红，再实现转绿