### PR TITLE
fix(web): 站点看板三处体验修复 (#70)

### DIFF
--- a/frontend/e2e/sites-board-fixes.spec.ts
+++ b/frontend/e2e/sites-board-fixes.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+// 单站点单模型。
+// latest_results 的「最近一次」成功率 = 98/100 = 98.0%；
+// 而可用率桶 series 覆盖整个时间范围、均值 = (100+100+50)/3 = 83.3%。
+// 用这个差异验证「成功率取所选范围（与可用率柱同源）而非最近一次」。
+const mockSitesSummary = {
+  summary: [
+    {
+      profile: { name: 'site-A', base_url: 'https://api-a.example.com', models: ['gpt-4o'] },
+      health: 'healthy',
+      last_test_at: '20260605_100000',
+      latest_results: [
+        {
+          config: { model: 'gpt-4o' },
+          summary: { total_requests: 100, success_count: 98, token_throughput_tps: 45 },
+          percentiles: { TTFT: { P50: 0.3 }, TPOT: { P50: 0.02 } },
+          error_details: [],
+        },
+      ],
+      // 长度 >= 2 才会渲染延迟趋势小图
+      sparkline_data: { 'gpt-4o': [0.3, 0.4, 0.35] },
+    },
+  ],
+};
+
+const mockAvailability = {
+  cells: [
+    { profile: 'site-A', model: 'gpt-4o', series: [100, 100, 50, null] },
+  ],
+};
+
+test.describe('站点健康看板修复（#70）', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('token', 'test-token');
+      localStorage.setItem('user', JSON.stringify({
+        username: 'testuser', role: 'admin', must_change_password: false,
+      }));
+    });
+    // 兜底先注册（后注册的同名匹配优先）
+    await page.route(/^https?:\/\/localhost:\d+\/api\//, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+    await page.route(/\/api\/sites\/summary/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSitesSummary) }));
+    await page.route(/\/api\/sites\/availability/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockAvailability) }));
+  });
+
+  test('#2 成功率取所选时间范围（可用率柱均值），而非最近一次', async ({ page }) => {
+    await page.goto('/sites');
+    const rate = page.locator('tr.site-row .rate').first();
+    await expect(rate).toBeVisible();
+    // 83.3%（series 均值），而不是 98.0%（最近一次）
+    await expect(rate).toHaveText('83.3%');
+  });
+
+  test('#1 展开后站点行的可用率柱变浅（dim），模型行出现', async ({ page }) => {
+    await page.goto('/sites');
+    const siteBars = page.locator('tr.site-row .avail-bars').first();
+    await expect(siteBars).toBeVisible();
+    await expect(siteBars).not.toHaveClass(/dim/);
+    await expect(page.locator('tr.model-row')).toHaveCount(0);
+
+    await siteBars.click(); // 点击站点行展开
+    await expect(page.locator('tr.model-row')).toHaveCount(1);
+    await expect(siteBars).toHaveClass(/dim/);
+  });
+
+  test('#3 延迟趋势小图为统一中性色（var(--text-secondary)）', async ({ page }) => {
+    await page.goto('/sites');
+    await page.locator('tr.site-row .avail-bars').first().click();
+    const poly = page.locator('tr.model-row polyline').first();
+    await expect(poly).toBeVisible();
+    await expect(poly).toHaveAttribute('stroke', 'var(--text-secondary)');
+  });
+});

--- a/frontend/src/utils/__tests__/siteMetrics.test.js
+++ b/frontend/src/utils/__tests__/siteMetrics.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { availabilityClass, buildAvailabilityLookup, siteAvgSeries } from '../siteMetrics';
+import { availabilityClass, buildAvailabilityLookup, siteAvgSeries, seriesAvg, latencyTrendColor } from '../siteMetrics';
 
 describe('availabilityClass', () => {
   it('按阈值分三档 + 空值', () => {
@@ -35,5 +35,29 @@ describe('siteAvgSeries', () => {
   it('空输入 → []', () => {
     expect(siteAvgSeries([])).toEqual([]);
     expect(siteAvgSeries([[], []])).toEqual([]);
+  });
+});
+
+describe('seriesAvg', () => {
+  it('非空桶的平均，忽略 null', () => {
+    expect(seriesAvg([100, null, 80])).toBe(90);
+    expect(seriesAvg([90])).toBe(90);
+    expect(seriesAvg([100, 81])).toBe(90.5);
+  });
+  it('全空 / 空 / 缺省 → null', () => {
+    expect(seriesAvg([null, null])).toBeNull();
+    expect(seriesAvg([])).toBeNull();
+    expect(seriesAvg()).toBeNull();
+  });
+});
+
+describe('latencyTrendColor', () => {
+  it('恒为统一中性色，不随涨跌变红/绿', () => {
+    const neutral = 'var(--text-secondary)';
+    expect(latencyTrendColor([1, 2, 3])).toBe(neutral);   // 上升
+    expect(latencyTrendColor([3, 2, 1])).toBe(neutral);   // 下降
+    expect(latencyTrendColor([2, 2, 2])).toBe(neutral);   // 持平
+    expect(latencyTrendColor([5])).toBe(neutral);          // 数据不足
+    expect(latencyTrendColor([])).toBe(neutral);
   });
 });

--- a/frontend/src/utils/siteMetrics.js
+++ b/frontend/src/utils/siteMetrics.js
@@ -80,16 +80,10 @@ export function sparklineEnd(values) {
   return { x: 60, y: 20 - ((last - min) / range) * 18 };
 }
 
-// 延迟趋势配色：延迟越低越好。上升=警示色，下降=绿色，基本持平=中性灰
-export function latencyTrendColor(values) {
-  if (!values || values.length < 2) return 'var(--text-tertiary)';
-  const first = values[0];
-  const last = values[values.length - 1];
-  if (first <= 0) return 'var(--text-tertiary)';
-  const pct = (last - first) / first;
-  if (pct > 0.05) return 'var(--danger)';
-  if (pct < -0.05) return 'var(--success)';
-  return 'var(--text-tertiary)';
+// 延迟趋势配色：统一中性色，只看走势形状。涨跌的具体数值交给 latencyTrendTooltip，
+// 不再用红/绿染色（红/绿会把"延迟变化方向"误导成"健康好坏"，且末点一抖就翻色）。
+export function latencyTrendColor() {
+  return 'var(--text-secondary)';
 }
 
 export function latencyTrendTooltip(values) {
@@ -186,4 +180,11 @@ export function siteAvgSeries(modelSeriesList) {
     out.push(vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null);
   }
   return out;
+}
+
+// 可用性序列 → 区间成功率：非空桶（!= null）的平均，全空/空/缺省 → null。
+// 用于把"成功率"数字与可用率柱同源，反映所选时间范围而非最近一次。
+export function seriesAvg(series) {
+  const vals = (series || []).filter(v => v != null);
+  return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
 }

--- a/frontend/src/views/SitesView.vue
+++ b/frontend/src/views/SitesView.vue
@@ -59,11 +59,11 @@
                 <router-link class="sname" :to="`/sites/${encodeURIComponent(site.profile.name)}`" @click.stop>{{ site.profile.name }}</router-link>
                 <span class="mcount">{{ getModelMetrics(site).length }} 模型</span>
               </td>
-              <td><span class="avail-bars"><i v-for="(rate,i) in siteSeries(site)" :key="i" :class="'ab-'+availabilityClass(rate)" :title="rate==null?'无数据':('成功率 '+rate.toFixed(1)+'%')"></i></span></td>
+              <td><span class="avail-bars" :class="{ dim: isExpanded(site.profile.name) }"><i v-for="(rate,i) in siteSeries(site)" :key="i" :class="'ab-'+availabilityClass(rate)" :title="rate==null?'无数据':('成功率 '+rate.toFixed(1)+'%')"></i></span></td>
               <td>{{ siteAvg(site,'ttft') != null ? fmtTime(siteAvg(site,'ttft')) : '-' }} <span class="agg" v-if="siteAvg(site,'ttft')!=null">平均</span></td>
               <td></td>
               <td>{{ siteAvg(site,'tps') != null ? fmtNum(siteAvg(site,'tps'),0) : '-' }}</td>
-              <td><span class="rate" :class="rateClass(siteAvg(site,'successRate'))">{{ siteAvg(site,'successRate')!=null ? fmtPct(siteAvg(site,'successRate')) : '-' }}</span></td>
+              <td><span class="rate" :class="rateClass(siteRate(site))">{{ siteRate(site)!=null ? fmtPct(siteRate(site)) : '-' }}</span></td>
               <td>{{ site.last_test_at ? relativeTime(site.last_test_at) : '未测试' }}</td>
               <td class="row-actions" @click.stop>
                 <button class="btn btn-ghost btn-sm" @click="testSite(site)">一键测试</button>
@@ -159,7 +159,7 @@ import { useAppStore } from '../stores/app';
 import { useTimeRangeStore } from '../stores/timeRange';
 import { api, getSitesSummary, getCellAvailability } from '../api';
 import { fmtTime, fmtPct, fmtNum } from '../utils/formatters';
-import { getModelMetrics, sparklinePoints, latencyTrendColor, availabilityClass, buildAvailabilityLookup, siteAvgSeries } from '../utils/siteMetrics';
+import { getModelMetrics, sparklinePoints, latencyTrendColor, availabilityClass, buildAvailabilityLookup, siteAvgSeries, seriesAvg } from '../utils/siteMetrics';
 import { toast } from '../composables/useToast';
 import { useRouter, useRoute } from 'vue-router';
 import ModalOverlay from '../components/ModalOverlay.vue';
@@ -199,11 +199,19 @@ function toggleExpand(name) { const n = new Set(expanded.value); n.has(name) ? n
 function isExpanded(name) { return expanded.value.has(name); }
 function modelRows(site) {
   const lut = availabilityLut.value[site.profile.name] || {};
-  return getModelMetrics(site).map(m => ({ ...m, series: lut[m.model] || [] }));
+  // 成功率取可用率柱（series）的均值，与柱同源、覆盖所选时间范围
+  return getModelMetrics(site).map(m => {
+    const series = lut[m.model] || [];
+    return { ...m, series, successRate: seriesAvg(series) };
+  });
 }
 function siteSeries(site) {
   const lut = availabilityLut.value[site.profile.name] || {};
   return siteAvgSeries(Object.values(lut));
+}
+// 站点成功率 = 站点可用率柱的均值（同源、反映所选时间范围，而非最近一次）
+function siteRate(site) {
+  return seriesAvg(siteSeries(site));
 }
 function siteAvg(site, key) {
   const vals = getModelMetrics(site).map(m => m[key]).filter(v => v != null);
@@ -236,7 +244,7 @@ function sortValue(site, key) {
     case 'avail': { const s = siteSeries(site).filter(v => v != null); return s.length ? s.reduce((a, b) => a + b, 0) / s.length : null; }
     case 'ttft': return siteAvg(site, 'ttft');
     case 'tps': return siteAvg(site, 'tps');
-    case 'rate': return siteAvg(site, 'successRate');
+    case 'rate': return siteRate(site);
     case 'last': return site.last_test_at || '';
     default: return null;
   }
@@ -541,6 +549,7 @@ onUnmounted(() => { store.refreshFn = null; });
 .avail-bars { display:inline-flex; align-items:flex-end; gap:1.5px; }
 .avail-bars i { display:inline-block; width:4px; height:16px; border-radius:1px; background:var(--border); }
 .avail-bars.sm i { height:13px; }
+.avail-bars.dim { opacity:.3; }
 .avail-bars i.ab-up { background:#21a366; }
 .avail-bars i.ab-degraded { background:#f5a623; }
 .avail-bars i.ab-down { background:#e5484d; }


### PR DESCRIPTION
## Summary
- **#1** 展开站点后淡化该行可用率柱（`.avail-bars` 加 `dim`/opacity .3），焦点转移到下方模型行
- **#2** 成功率改按**所选时间范围**聚合（取可用率柱 series 的均值，与柱同源），不再表现为「最近一次」
- **#3** 延迟趋势小图配色**中性化**（`latencyTrendColor` 恒返回 `var(--text-secondary)`），去掉「末值 vs 首值」涨跌红/绿

### 实现要点
- 新增纯函数 `seriesAvg(series)`；看板站点行/模型行/排序的成功率统一改用它
- 成功率 bug 根因：旧值来自 `getModelMetrics → latest_results`，后端 `get_sites_summary` 每站点仅取最近 5 条，多模型站点摊到每模型常只剩 1 条 → 实为「最近一次」
- `latencyTrendColor` 中性化同时影响站点详情「概览」页的同款小图（同一逻辑，符合预期）

Closes #70

## Test plan
- [x] `vitest` 全量 46 项通过（新增 `seriesAvg` / `latencyTrendColor` 单测）
- [x] `vite build` 通过
- [x] Playwright(chromium) 新增看板 e2e：成功率显示 **83.3%**（区间均值）而非 98.0%（最近一次）；展开后站点柱 `dim`；趋势小图 stroke=`var(--text-secondary)`
- [ ] 人工在真实数据下浏览器核对三处表现