### PR TITLE
chore: gitignore 忽略 .claude/worktrees/ (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 # Visual companion
 .superpowers/
 
+# Claude Code worktrees
+.claude/worktrees/
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- `.claude/worktrees/` 是 git worktree 存放目录（运行时产物、无被跟踪文件），但会在 `git status` 持续显示为未跟踪噪音 → 加入 `.gitignore`

Closes #74