### PR TITLE
fix: 站点改名在 Postgres 报 500（to_jsonb 绑定参数类型推断失败）

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -701,7 +701,7 @@ async def rename_profile(user_id: int, old_name: str, new_name: str) -> bool:
             await conn.execute(
                 text("""
                     UPDATE results
-                    SET config_json = jsonb_set(config_json::jsonb, '{profile_name}', to_jsonb(:new))::text
+                    SET config_json = jsonb_set(config_json::jsonb, '{profile_name}', to_jsonb(cast(:new as text)))::text
                     WHERE user_id=:uid
                       AND config_json::jsonb->>'profile_name' = :old
                 """),


### PR DESCRIPTION
## 问题
生产（Postgres/asyncpg）对任意站点改名，`POST /api/profiles/{name}/rename` 返回 500。

## 根因
`rename_profile` 级联更新 `results.config_json` 内嵌 `profile_name` 的 postgres 分支：

```sql
SET config_json = jsonb_set(config_json::jsonb, '{profile_name}', to_jsonb(:new))::text
```

asyncpg 走预编译语句，`to_jsonb()` 是多态函数，Postgres 在 Parse 阶段无法推断绑定参数 `$1` 的类型 → `could not determine data type of parameter`。该 UPDATE 每次改名都执行，所以生产改任何站点都 500。单测仅跑 sqlite（走 `json_set` 分支）故未暴露。

## 修复
`to_jsonb(:new)` → `to_jsonb(cast(:new as text))`，显式声明参数类型。

## 验证
- `tests/test_rename_profile.py` 5 项全过（sqlite 级联逻辑无回归）
- postgres 路径本地无库，依据 asyncpg 多态参数推断的标准修法

Closes #83