### PR TITLE
chore: 清理 pre-existing 未用 import

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """认证模块 — bcrypt 密码哈希 + JWT token (FastAPI 版)"""
 
-import hashlib
 import os
 import time
 from pathlib import Path

--- a/app/db.py
+++ b/app/db.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import event, text
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncConnection
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.config import DATABASE_URL
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import logging
 import random
-import time
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -15,7 +14,6 @@ from app.db import (
     get_scheduled_task,
     update_scheduled_task,
     get_profiles,
-    get_settings,
     get_user_by_id,
     claim_scheduled_task,
     release_scheduled_task,

--- a/app/server.py
+++ b/app/server.py
@@ -13,24 +13,23 @@ from pathlib import Path
 from typing import Optional
 
 import aiohttp as aiohttp_lib
-from fastapi import FastAPI, Depends, Query, Path as FPath, HTTPException, Request
+from fastapi import FastAPI, Depends, Query, Request
 from fastapi.responses import JSONResponse, FileResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.client import send_streaming_request
 from app.stats import aggregate_metrics, build_report_dict
 from app.logger import log_access, log_security, current_run_id
 
 log = logging.getLogger("server")
-from app.db import init_db, close_db, get_profiles, get_active_profile, upsert_profile
+from app.db import close_db, get_profiles, get_active_profile, upsert_profile
 from app.db import switch_active_profile, delete_profile as db_delete_profile, rename_profile as db_rename_profile
-from app.db import save_result as db_save_result, get_results as db_get_results
+from app.db import save_result as db_save_result
 from app.db import get_results_aggregated as db_get_results_aggregated
 from app.db import get_result_by_filename, delete_result as db_delete_result
 from app.db import get_settings, save_settings
 from app.db import save_channel_diagnostic, get_channel_diagnostic, list_channel_diagnostics, list_diagnostic_filter_options
-from app.diagnostics import run_diagnostics, get_available_categories
+from app.diagnostics import run_diagnostics
 from app.db import get_sites_summary as db_get_sites_summary
 from app.db import create_user, get_user_by_email, get_user_by_id, update_user_password, count_users
 from app.db import list_users, update_user_display_name, update_user_role, delete_user as db_delete_user
@@ -470,7 +469,6 @@ async def _run_benchmark_task(config: dict, owner_id: int, task: BenchTask):
             })
 
     except Exception as e:
-        import traceback
         log_security("bench_error", error=str(e))
         log.error("bench error: %s", e, exc_info=True)
         await _publish(task, "bench:error", {"error": "Benchmark execution failed, check server logs for details"})
@@ -732,7 +730,6 @@ async def test_reset():
     async with _test_reset_lock:
         from sqlalchemy import text
         from app.db import engine, init_db
-        from app.migrate import migrate
 
         async with engine.begin() as conn:
             for table in ["scheduled_tasks", "user_settings", "results", "profiles", "sessions", "users"]:
@@ -2107,7 +2104,7 @@ async def active_alerts(user: dict = Depends(get_current_user)):
 
 @app.post("/api/schedules")
 async def create_schedule(request: Request, user: dict = Depends(get_current_user)):
-    from app.db import create_scheduled_task, get_scheduled_task, count_user_scheduled_tasks
+    from app.db import create_scheduled_task, count_user_scheduled_tasks
     user_id = user["user_id"]
     body = await request.json()
     name = body.get("name", "").strip()

--- a/app/stats.py
+++ b/app/stats.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Claude API SSE 流式压测工具 - 统计与报表模块"""
 
-import json
-import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime


### PR DESCRIPTION
## 背景
普查 #85 时发现一批与功能无关的未用 import（pyflakes `imported but unused`），单独清理，**不改任何逻辑**。

## 删除项
| 文件 | 删除的未用 import |
|---|---|
| app/auth.py | `hashlib` |
| app/db.py | `AsyncConnection` |
| app/scheduler.py | `time`、`app.db.get_settings` |
| app/stats.py | `json`、`os` |
| app/server.py | `fastapi.Path as FPath`、`fastapi.HTTPException`、`app.client.send_streaming_request`、模块级 `app.db.init_db`、`get_results as db_get_results`、`diagnostics.get_available_categories`；局部 `import traceback` / `app.migrate.migrate` / `app.db.get_scheduled_task` |

## 核实
- 无 `__all__` 重导出受影响（`get_available_categories` 仍由 diagnostics 包导出，仅 server.py 未用到）。
- 局部 import 上下文确认未调用（如 `migrate` 处注释明说「跳过 migrate」、`traceback` 处改用 `exc_info=True`）。
- 跨文件无属性引用（grep `db_get_results`/`send_streaming_request`/`FPath` 等均无外部使用）。
- 主模块 import 冒烟通过；`py_compile` OK；pyflakes 不再报本范围的 `imported but unused`；相关测试通过。

## 备注
`app/migrate.py` 的未用 import（sys/close_db/get_user_by_email）由 #85 处理，本 PR 不重复，避免冲突。

Closes #87