### PR TITLE
refactor: 告警改为站点×模型滑动窗口失败计数 (#89)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -121,6 +121,7 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     alert_threshold INTEGER NOT NULL DEFAULT 90,
     alert_enabled   INTEGER NOT NULL DEFAULT 0,
     alert_state     TEXT NOT NULL DEFAULT 'ok',
+    alert_rules     TEXT NOT NULL DEFAULT '',
     created_at      TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -231,6 +232,7 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     alert_threshold INTEGER NOT NULL DEFAULT 90,
     alert_enabled   BOOLEAN NOT NULL DEFAULT FALSE,
     alert_state     TEXT NOT NULL DEFAULT 'ok',
+    alert_rules     TEXT NOT NULL DEFAULT '',
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -338,6 +340,7 @@ async def init_db():
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_enabled INTEGER NOT NULL DEFAULT 0",
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_state TEXT NOT NULL DEFAULT 'ok'",
                 "ALTER TABLE scheduled_tasks ADD COLUMN alert_notifier_id INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE scheduled_tasks ADD COLUMN alert_rules TEXT NOT NULL DEFAULT ''",
             ]:
                 try:
                     await conn.execute(text(col_def))
@@ -350,6 +353,7 @@ async def init_db():
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE",
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_state TEXT NOT NULL DEFAULT 'ok'",
                 "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_notifier_id INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS alert_rules TEXT NOT NULL DEFAULT ''",
             ]:
                 await conn.execute(text(col_def))
 
@@ -933,6 +937,68 @@ async def get_cell_availability_series(user_id: int, hours: int | None = None,
     return out
 
 
+async def get_task_window_rounds_by_cell(
+    task_id: int, threshold: int, mode: str = "time", value: int = 1
+) -> dict:
+    """取某定时任务窗口内各 (profile_name, model) 的「坏轮」序列，用于滑动窗口告警。
+
+    一轮 = 同一 run_id 内该格所有并发档聚合后的 (success, total)；
+    bad = 该轮成功率 < threshold（total==0 的轮不计入序列）。
+    mode='time': 取最近 value 小时内的轮；mode='count': 每格取最近 value 轮。
+    返回 {(profile, model): [bad_bool, ...]}（按轮代表时间旧→新）。
+    分组口径与 get_run_success_rate_by_cell 一致（profile_name 列；config.model 缺失归 '-'）。"""
+    from datetime import datetime, timedelta
+    params: dict = {"tid": task_id}
+    sql = ("SELECT profile_name, config_json, summary_json, run_id, timestamp "
+           "FROM results WHERE scheduled_task_id = :tid")
+    if mode == "time":
+        window_h = value if (value and value > 0) else 1
+        cutoff = (datetime.now() - timedelta(hours=window_h)).strftime("%Y%m%d_%H%M%S")
+        sql += " AND timestamp >= :cutoff"
+        params["cutoff"] = cutoff
+    async with engine.connect() as conn:
+        cur = await conn.execute(text(sql), params)
+        rows = cur.fetchall()
+
+    # acc[(profile, model)][run_id] = [succ, tot, min_ts]，把同轮多并发档合并成一轮
+    acc: dict = {}
+    for profile_name, config_json, summary_json, run_id, ts in rows:
+        try:
+            cfg = json.loads(config_json) if config_json else {}
+        except (json.JSONDecodeError, TypeError):
+            cfg = {}
+        try:
+            s = json.loads(summary_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        profile = profile_name or "-"
+        model = cfg.get("model") or "-"
+        succ = int(s.get("success_count") or 0)
+        tot = int(s.get("total_requests") or 0)
+        rid = run_id or (ts or "")          # run_id 缺失时退化为按 timestamp 分轮
+        rounds = acc.setdefault((profile, model), {})
+        r = rounds.get(rid)
+        if r is None:
+            rounds[rid] = [succ, tot, ts or ""]
+        else:
+            r[0] += succ
+            r[1] += tot
+            if ts and (not r[2] or ts < r[2]):
+                r[2] = ts
+
+    out: dict = {}
+    for cell, rounds in acc.items():
+        ordered = sorted(rounds.values(), key=lambda r: r[2])   # 旧→新
+        # bad: 成功率 < threshold，用乘法避免浮点除零（tot>0 已保证）
+        series = [succ < tot * threshold / 100.0
+                  for succ, tot, _ in ordered if tot > 0]
+        if mode == "count":
+            n = value if (value and value > 0) else 10
+            series = series[-n:]
+        out[cell] = series
+    return out
+
+
 def _row_to_result_dict(row, lightweight: bool = False) -> dict:
     d = dict(row._mapping)
     d["config"] = json.loads(d["config_json"])
@@ -1405,16 +1471,19 @@ async def create_scheduled_task(user_id: int, name: str, profile_ids: list,
                                  configs_json: dict, schedule_type: str,
                                  schedule_value: str, alert_notifier_id: int = 0,
                                  alert_threshold: int = 90,
-                                 alert_enabled: bool = False) -> int:
+                                 alert_enabled: bool = False,
+                                 alert_rules: str = '') -> int:
     async with engine.begin() as conn:
         cur = await conn.execute(
             text("""INSERT INTO scheduled_tasks (user_id, name, profile_ids, configs_json,
-                    schedule_type, schedule_value, alert_notifier_id, alert_threshold, alert_enabled)
-                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :ani, :at, :ae)"""),
+                    schedule_type, schedule_value, alert_notifier_id, alert_threshold,
+                    alert_enabled, alert_rules)
+                   VALUES (:uid, :name, :pids, :cj, :st, :sv, :ani, :at, :ae, :ar)"""),
             {"uid": user_id, "name": name, "pids": json.dumps(profile_ids),
              "cj": json.dumps(configs_json), "st": schedule_type, "sv": schedule_value,
              "ani": alert_notifier_id, "at": alert_threshold,
-             "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled)},
+             "ae": (1 if alert_enabled else 0) if _is_sqlite else bool(alert_enabled),
+             "ar": alert_rules or ''},
         )
         if _is_sqlite:
             return cur.lastrowid
@@ -1479,7 +1548,7 @@ async def update_scheduled_task(task_id: int, **fields):
         allowed = {"name", "profile_ids", "configs_json", "schedule_type",
                    "schedule_value", "status", "last_run_at", "next_run_at", "run_count",
                    "alert_threshold", "alert_enabled", "alert_state",
-                   "alert_notifier_id"}
+                   "alert_notifier_id", "alert_rules"}
         set_parts = []
         values = {"id": task_id}
         for k, v in fields.items():

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -14,22 +14,68 @@ ALERT_OK = "ok"
 ALERT_ALERTING = "alerting"
 FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
 
+# 滑动窗口告警默认规则：
+#   mode='time'  → 取最近 value 小时内的轮；'count' → 每格取最近 value 轮
+#   fail_consecutive   末尾连续坏轮 ≥ 此值 → 告警（抓硬故障）
+#   fail_in_window     窗口内累计坏轮 ≥ 此值 → 告警（抓间歇抖动，容忍偶发）
+#   recover_consecutive 告警中末尾连续好轮 ≥ 此值 → 恢复
+DEFAULT_ALERT_RULES = {
+    "mode": "time", "value": 1,
+    "fail_consecutive": 2, "fail_in_window": 3, "recover_consecutive": 2,
+}
+_MIN_SAMPLES = 2   # 窗口内有效轮数不足则视为冷启动，不评估
 
-def evaluate_alert(prev_state: str, prev_streak: int, success_rate: float,
-                   threshold: int, fail_needed: int = 2) -> Tuple[str, int, Optional[str]]:
-    """连续 fail_needed 次低于阈值才告警；恢复 1 次回到阈值即报（防抖）。
-    返回 (新状态, 新连续异常计数, 动作)。动作 ∈ {None, 'alert', 'recover'}。"""
-    abnormal = success_rate < threshold
-    if abnormal:
-        if prev_state == ALERT_ALERTING:
-            return ALERT_ALERTING, prev_streak, None      # 已在告警，保持不重复发
-        streak = prev_streak + 1
-        if streak >= fail_needed:
-            return ALERT_ALERTING, streak, "alert"        # 连续达标，翻红告警
-        return ALERT_OK, streak, None                     # 仍在累积，先不发
+
+def _load_rules(raw) -> dict:
+    """读取 alert_rules（JSON 串）并与默认规则合并。空/非法一律回退默认。"""
+    rules = dict(DEFAULT_ALERT_RULES)
+    if not raw:
+        return rules
+    try:
+        v = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        return rules
+    if isinstance(v, dict):
+        for k in DEFAULT_ALERT_RULES:
+            if v.get(k) is not None:
+                rules[k] = v[k]
+    return rules
+
+
+def evaluate_window(rounds: list, prev_state: str,
+                    rules: dict) -> Tuple[str, Optional[str], int]:
+    """基于「坏轮序列」做滑动窗口判定。
+    rounds: 旧→新 的 bool 序列（True=该轮成功率低于单轮健康线，即坏轮）。
+    返回 (新状态, 动作, 窗口内坏轮数)。动作 ∈ {None, 'alert', 'recover'}。
+    样本不足（< _MIN_SAMPLES）视为冷启动：保留旧态、不动作。"""
+    fail_count = sum(1 for b in rounds if b)
+    if len(rounds) < _MIN_SAMPLES:
+        return prev_state, None, fail_count
+
+    fc = int(rules.get("fail_consecutive", 2) or 2)
+    fw = int(rules.get("fail_in_window", 3) or 3)
+    rc = int(rules.get("recover_consecutive", 2) or 2)
+
+    consec_fail = 0
+    for b in reversed(rounds):
+        if b:
+            consec_fail += 1
+        else:
+            break
+    consec_good = 0
+    for b in reversed(rounds):
+        if not b:
+            consec_good += 1
+        else:
+            break
+
     if prev_state == ALERT_ALERTING:
-        return ALERT_OK, 0, "recover"                     # 一次回到阈值即恢复
-    return ALERT_OK, 0, None                              # 一直正常
+        if consec_good >= rc:
+            return ALERT_OK, "recover", fail_count          # 连续好轮够 → 恢复
+        return ALERT_ALERTING, None, fail_count             # 保持告警，不重复发
+    if consec_fail >= fc or fail_count >= fw:
+        return ALERT_ALERTING, "alert", fail_count          # 连续坏 或 累计坏 → 告警
+    return ALERT_OK, None, fail_count
 
 
 def _load_alert_states(raw) -> dict:
@@ -44,15 +90,16 @@ def _load_alert_states(raw) -> dict:
 
 
 def _cell_state(value) -> Tuple[str, int]:
-    """解析单格状态，返回 (状态, 连续异常计数)。
-    兼容旧的裸字符串（"ok"/"alerting"）与新的 {"s": 状态, "n": 连续计数}。"""
+    """解析单格状态，返回 (状态, 窗口内坏轮数)。
+    n 字段在滑动窗口模型下表示「窗口内坏轮数」（仅供展示，判定每次从 results 实时重算）。
+    兼容旧的裸字符串（"ok"/"alerting"）与 {"s": 状态, "n": 计数}。"""
     if isinstance(value, dict):
         state = value.get("s", ALERT_OK)
         try:
-            streak = int(value.get("n", 0) or 0)
+            fail_count = int(value.get("n", 0) or 0)
         except (TypeError, ValueError):
-            streak = 0
-        return (state if state in (ALERT_OK, ALERT_ALERTING) else ALERT_OK), streak
+            fail_count = 0
+        return (state if state in (ALERT_OK, ALERT_ALERTING) else ALERT_OK), fail_count
     if isinstance(value, str) and value in (ALERT_OK, ALERT_ALERTING):
         return value, 0
     return ALERT_OK, 0
@@ -62,8 +109,9 @@ def aggregate_active_alerts(tasks: list) -> list:
     """把多个任务的 alert_state 聚合为"当前正在告警"的格子列表，按 (站点,模型) 合并。
     入参 tasks: get_scheduled_tasks() 返回的 dict 列表（含 alert_state/name/id/profile_ids）。
     前置条件：每个 task 应含 id 字段（来自 get_scheduled_tasks 的主键，必非空）。
-    出参: [{"profile","model","streak","task_count","tasks":[{"id","name"}]}, ...]，
-    按 (profile, model) 排序，便于前端稳定渲染。"""
+    出参: [{"profile","model","fail_count","task_count","tasks":[{"id","name"}]}, ...]，
+    按 (profile, model) 排序，便于前端稳定渲染。
+    fail_count = 该格当前窗口内的坏轮数（取所属任务中的最大值）。"""
     merged: dict = {}
     for t in tasks:
         states = _load_alert_states(t.get("alert_state"))
@@ -71,15 +119,15 @@ def aggregate_active_alerts(tasks: list) -> list:
             if not isinstance(models, dict):
                 continue
             for model, cellval in models.items():
-                state, streak = _cell_state(cellval)
+                state, fail_count = _cell_state(cellval)
                 if state != ALERT_ALERTING:
                     continue
                 key = (profile, model)
                 entry = merged.setdefault(key, {
                     "profile": profile, "model": model,
-                    "streak": 0, "task_count": 0, "tasks": [],
+                    "fail_count": 0, "task_count": 0, "tasks": [],
                 })
-                entry["streak"] = max(entry["streak"], streak)
+                entry["fail_count"] = max(entry["fail_count"], fail_count)
                 entry["tasks"].append({"id": t.get("id"), "name": t.get("name", "")})
     out = []
     for (profile, model), entry in sorted(merged.items()):
@@ -113,7 +161,9 @@ def build_feishu_card(kind: str, task_name: str,
                       cells: list, threshold: int, ts: str,
                       base_url: str = "") -> dict:
     """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
-    cells: [(profile, model, rate), ...] —— 本轮新翻转的格子。
+    cells: [(profile, model, fail_count, total), ...] —— 本轮新翻转的格子，
+           fail_count=窗口内坏轮数，total=窗口内有效轮数。
+    threshold: 单轮健康线（单次拨测成功率 < threshold% 记为一次失败）。
     base_url: 公开访问基址（如 https://app.aitokenperf.com），空则不加跳转按钮。"""
     n = len(cells)
     cell = f" · {cells[0][0]}/{cells[0][1]}" if cells else ""  # 首个异常的站点/模型，手机一眼定位
@@ -121,21 +171,22 @@ def build_feishu_card(kind: str, task_name: str,
     if kind == "recover":
         template = color = "green"
         title = f"✅ 已恢复{cell}{label}（{n} 个）"
-        summary = f"以下 {n} 个格子已恢复（成功率 ≥ 阈值 {threshold}%）"
+        summary = f"以下 {n} 个格子拨测已恢复稳定"
     else:
         template = color = "red"
         title = f"🔴 拨测告警{cell}{label}（{n} 个异常）"
-        summary = f"本轮 {n} 个格子成功率低于阈值 {threshold}%"
+        summary = (f"以下 {n} 个格子近窗口内拨测失败次数超限"
+                   f"（单次成功率 < {threshold}% 记为一次失败）")
     elements = [
         {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},
         {"tag": "div", "text": {"tag": "lark_md", "content": summary}},
     ]
-    for profile, model, rate in cells:
+    for profile, model, fail_count, total in cells:
         elements.append({"tag": "div", "fields": [
             {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
             {"is_short": True, "text": {"tag": "lark_md", "content": f"**模型**\n{model}"}},
             {"is_short": True, "text": {"tag": "lark_md",
-                "content": f"**成功率**\n<font color='{color}'>{rate:.1f}%</font>"}},
+                "content": f"**失败**\n<font color='{color}'>{fail_count}/{total} 次</font>"}},
         ]})
     if base_url and cells:
         base_url = base_url.rstrip("/")

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -223,11 +223,16 @@ class TaskScheduler:
 # ── 模块级工具函数 ───────────────────────────────────────
 
 async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
-    """按 (站点,模型) 格子聚合成功率，逐格状态翻转，聚合成红/绿卡发送。全程不抛。"""
-    from app.db import get_run_success_rate_by_cell, get_notifier
+    """按 (站点,模型) 在滑动窗口内数坏轮，逐格状态翻转，聚合成红/绿卡发送。全程不抛。
+
+    单轮健康线 = alert_threshold（单次成功率 < 此值记为一次失败）；
+    告警规则 = alert_rules（连续坏轮 / 窗口内累计坏轮 / 恢复连续好轮）。"""
+    from app.db import (
+        get_run_success_rate_by_cell, get_task_window_rounds_by_cell, get_notifier,
+    )
     from app.notifier import (
-        evaluate_alert, build_feishu_card, send_webhook,
-        _load_alert_states, _cell_state,
+        evaluate_window, build_feishu_card, send_webhook,
+        _load_alert_states, _cell_state, _load_rules, ALERT_ALERTING,
     )
     from app.config import APP_PUBLIC_URL
 
@@ -240,27 +245,46 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
         log.info("定时任务 #%d 告警器缺失或 webhook 空，跳过告警", task_id)
         return
 
+    # 本轮出现的格子集合（只评估这些，避免对已消失的格子误判）
     cells = await get_run_success_rate_by_cell(run_ids)
     if not cells:
         log.info("定时任务 #%d 本轮无有效请求，跳过告警评估", task_id)
         return
 
     threshold = int(task_row.get("alert_threshold") or 90)
+    rules = _load_rules(task_row.get("alert_rules"))
+    mode = rules.get("mode", "time")
+    value = int(rules.get("value", 1) or 1)
+    # 各格窗口内坏轮序列（含本轮，本轮结果已落库）
+    windows = await get_task_window_rounds_by_cell(task_id, threshold, mode, value)
+
     prev = _load_alert_states(task_row.get("alert_state"))
     new_states: dict = {}
     alerts, recovers = [], []
-    for (profile, model), (succ, tot) in cells.items():
-        p_state, p_streak = _cell_state(prev.get(profile, {}).get(model))
-        if tot == 0:                       # 没真发出请求 → 不评估、保留旧态
-            new_states.setdefault(profile, {})[model] = {"s": p_state, "n": p_streak}
-            continue
-        rate = succ / tot * 100
-        n_state, n_streak, action = evaluate_alert(p_state, p_streak, rate, threshold)
-        new_states.setdefault(profile, {})[model] = {"s": n_state, "n": n_streak}
+    for (profile, model) in cells:
+        rounds = windows.get((profile, model), [])
+        p_state, _ = _cell_state(prev.get(profile, {}).get(model))
+        n_state, action, fail_count = evaluate_window(rounds, p_state, rules)
+        new_states.setdefault(profile, {})[model] = {"s": n_state, "n": fail_count}
+        total = len(rounds)
         if action == "alert":
-            alerts.append((profile, model, rate))
+            alerts.append((profile, model, fail_count, total))
         elif action == "recover":
-            recovers.append((profile, model, rate))
+            recovers.append((profile, model, fail_count, total))
+
+    # 本轮未出现但仍在告警的旧格子：保留状态，避免临时跳过（如容量不足）丢失告警
+    for profile, models in prev.items():
+        if not isinstance(models, dict):
+            continue
+        for model, cellval in models.items():
+            if model in new_states.get(profile, {}):
+                continue
+            st, fc = _cell_state(cellval)
+            if st == ALERT_ALERTING:
+                latest = windows.get((profile, model))   # 窗口内仍有数据则刷新失败数
+                if latest:
+                    fc = sum(1 for b in latest if b)
+                new_states.setdefault(profile, {})[model] = {"s": st, "n": fc}
 
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     name = task_row.get("name", "")

--- a/app/server.py
+++ b/app/server.py
@@ -2078,6 +2078,30 @@ async def _extract_alert_fields(body: dict, user_id: int):
             if not n or n["user_id"] != user_id:
                 return None, "告警器不存在或无权使用"
         out["alert_notifier_id"] = nid
+    if "alert_rules" in body:
+        raw = body.get("alert_rules")
+        if isinstance(raw, dict):
+            rules = raw
+        elif isinstance(raw, str) and raw.strip():
+            try:
+                rules = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return None, "alert_rules 格式非法"
+        else:
+            rules = {}
+        if not isinstance(rules, dict):
+            return None, "alert_rules 必须是对象"
+        if rules.get("mode") not in (None, "time", "count"):
+            return None, "alert_rules.mode 必须是 time 或 count"
+        for k in ("value", "fail_consecutive", "fail_in_window", "recover_consecutive"):
+            if rules.get(k) is not None:
+                try:
+                    iv = int(rules[k])
+                except (ValueError, TypeError):
+                    return None, f"alert_rules.{k} 必须是正整数"
+                if iv < 1:
+                    return None, f"alert_rules.{k} 必须 ≥ 1"
+        out["alert_rules"] = json.dumps(rules, ensure_ascii=False)
     return out, None
 
 
@@ -2145,6 +2169,7 @@ async def create_schedule(request: Request, user: dict = Depends(get_current_use
         alert_notifier_id=alert_fields.get("alert_notifier_id", 0),
         alert_threshold=alert_fields.get("alert_threshold", 90),
         alert_enabled=alert_fields.get("alert_enabled", False),
+        alert_rules=alert_fields.get("alert_rules", ""),
     )
     if _scheduler:
         _scheduler.start_loop(sid)
@@ -2335,7 +2360,7 @@ async def notifier_test(notifier_id: int, user: dict = Depends(get_current_user)
     if not webhook or not is_allowed_webhook(webhook):
         return JSONResponse({"error": "该告警器 webhook 非法"}, status_code=400)
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    card = build_feishu_card("alert", n.get("name", ""), [("测试", "测试", 0.0)], 90, ts)
+    card = build_feishu_card("alert", n.get("name", ""), [("测试", "测试", 3, 12)], 90, ts)
     card["card"]["header"]["title"]["content"] = "🔔 告警测试（这是一条测试消息）"
     ok = await send_webhook(webhook, card)
     return {"ok": ok}

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -117,9 +117,36 @@
               <div class="form-hint" style="color:var(--danger)" v-if="createForm.alert_notifier_id === 0">⚠️ 已开启告警但未选择告警器，将不会发送通知</div>
             </div>
             <div class="form-group">
-              <label class="form-label">成功率阈值（%）</label>
+              <label class="form-label">单次成功率阈值（%）</label>
               <input class="form-input" type="number" v-model.number="createForm.alert_threshold" min="0" max="100" placeholder="90">
-              <div class="form-hint">上次运行成功率低于该值时触发告警；测试消息可在创建后编辑时发送</div>
+              <div class="form-hint">单次拨测成功率低于此值记为「一次失败」（每轮 1 个请求时即这次成没成功）</div>
+            </div>
+            <div class="form-group full">
+              <label class="form-label">告警窗口</label>
+              <div style="display:flex;gap:8px;align-items:center">
+                <select class="form-input" v-model="createForm.alert_rules.mode" style="width:auto;flex:0 0 auto">
+                  <option value="time">最近 N 小时</option>
+                  <option value="count">最近 N 次</option>
+                </select>
+                <input class="form-input" type="number" v-model.number="createForm.alert_rules.value" min="1" style="width:90px">
+                <span class="form-hint" style="margin:0">{{ createForm.alert_rules.mode === 'time' ? '小时' : '次' }}</span>
+              </div>
+              <div class="form-hint">在此窗口内统计失败次数（5 分钟一拨时，1 小时 ≈ 12 次）</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">连续失败几次告警</label>
+              <input class="form-input" type="number" v-model.number="createForm.alert_rules.fail_consecutive" min="1" placeholder="2">
+              <div class="form-hint">抓硬故障（站点真挂），默认连续 2 次</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">窗口内累计几次告警</label>
+              <input class="form-input" type="number" v-model.number="createForm.alert_rules.fail_in_window" min="1" placeholder="3">
+              <div class="form-hint">抓间歇抖动，默认累计 3 次（容忍偶发 1 次）</div>
+            </div>
+            <div class="form-group">
+              <label class="form-label">连续几次成功才算恢复</label>
+              <input class="form-input" type="number" v-model.number="createForm.alert_rules.recover_consecutive" min="1" placeholder="2">
+              <div class="form-hint">防抖动误恢复，默认连续 2 次成功</div>
             </div>
           </template>
         </div>
@@ -317,9 +344,36 @@
             <div class="form-hint" style="color:var(--danger)" v-if="editForm.alert_notifier_id === 0">⚠️ 已开启告警但未选择告警器，将不会发送通知</div>
           </div>
           <div class="form-group">
-            <label class="form-label">成功率阈值（%）</label>
+            <label class="form-label">单次成功率阈值（%）</label>
             <input class="form-input" type="number" v-model.number="editForm.alert_threshold" min="0" max="100" placeholder="90">
-            <div class="form-hint">上次运行成功率低于该值时触发告警</div>
+            <div class="form-hint">单次拨测成功率低于此值记为「一次失败」（每轮 1 个请求时即这次成没成功）</div>
+          </div>
+          <div class="form-group full">
+            <label class="form-label">告警窗口</label>
+            <div style="display:flex;gap:8px;align-items:center">
+              <select class="form-input" v-model="editForm.alert_rules.mode" style="width:auto;flex:0 0 auto">
+                <option value="time">最近 N 小时</option>
+                <option value="count">最近 N 次</option>
+              </select>
+              <input class="form-input" type="number" v-model.number="editForm.alert_rules.value" min="1" style="width:90px">
+              <span class="form-hint" style="margin:0">{{ editForm.alert_rules.mode === 'time' ? '小时' : '次' }}</span>
+            </div>
+            <div class="form-hint">在此窗口内统计失败次数（5 分钟一拨时，1 小时 ≈ 12 次）</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">连续失败几次告警</label>
+            <input class="form-input" type="number" v-model.number="editForm.alert_rules.fail_consecutive" min="1" placeholder="2">
+            <div class="form-hint">抓硬故障（站点真挂），默认连续 2 次</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">窗口内累计几次告警</label>
+            <input class="form-input" type="number" v-model.number="editForm.alert_rules.fail_in_window" min="1" placeholder="3">
+            <div class="form-hint">抓间歇抖动，默认累计 3 次（容忍偶发 1 次）</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">连续几次成功才算恢复</label>
+            <input class="form-input" type="number" v-model.number="editForm.alert_rules.recover_consecutive" min="1" placeholder="2">
+            <div class="form-hint">防抖动误恢复，默认连续 2 次成功</div>
           </div>
         </template>
       </div>
@@ -409,7 +463,24 @@ function defaultCreateForm() {
     alert_enabled: false,
     alert_notifier_id: 0,
     alert_threshold: 90,
+    alert_rules: defaultAlertRules(),
   };
+}
+
+// 滑动窗口告警默认规则；与后端 notifier.DEFAULT_ALERT_RULES 保持一致
+function defaultAlertRules() {
+  return { mode: 'time', value: 1, fail_consecutive: 2, fail_in_window: 3, recover_consecutive: 2 };
+}
+
+// 后端 alert_rules 存为 JSON 字符串；解析并补全缺省字段，非法回退默认
+function parseAlertRules(raw) {
+  const def = defaultAlertRules();
+  if (!raw) return def;
+  try {
+    return { ...def, ...(typeof raw === 'string' ? JSON.parse(raw) : raw) };
+  } catch {
+    return def;
+  }
 }
 
 const createForm = ref(defaultCreateForm());
@@ -450,6 +521,7 @@ const editForm = ref({
   alert_enabled: false,
   alert_notifier_id: 0,
   alert_threshold: 90,
+  alert_rules: defaultAlertRules(),
 });
 
 // ---- Multi-model select ----
@@ -527,6 +599,7 @@ function startEdit(s) {
     alert_enabled: !!s.alert_enabled,
     alert_notifier_id: s.alert_notifier_id || 0,
     alert_threshold: s.alert_threshold != null ? s.alert_threshold : 90,
+    alert_rules: parseAlertRules(s.alert_rules),
   };
   // Detect preset or custom
   const sv = String(s.schedule_value);
@@ -631,6 +704,7 @@ async function createSchedule() {
       alert_enabled: !!f.alert_enabled,
       alert_notifier_id: f.alert_notifier_id || 0,
       alert_threshold: parseInt(f.alert_threshold) || 90,
+      alert_rules: f.alert_rules || defaultAlertRules(),
     };
     const res = await createScheduleApi(payload);
     if (res.error) {
@@ -679,6 +753,7 @@ async function saveEdit() {
       alert_enabled: !!f.alert_enabled,
       alert_notifier_id: f.alert_notifier_id || 0,
       alert_threshold: parseInt(f.alert_threshold) || 90,
+      alert_rules: f.alert_rules || defaultAlertRules(),
     });
     if (res.error) {
       toast(res.error, 'error');

--- a/frontend/src/views/SitesView.vue
+++ b/frontend/src/views/SitesView.vue
@@ -20,12 +20,12 @@
       </div>
     </div>
 
-    <!-- 告警卡区（连续 2 轮才翻红；无告警不显示） -->
+    <!-- 告警卡区（滑动窗口内失败次数超限才翻红；无告警不显示） -->
     <div v-if="alerts.length" class="alert-area">
       <div v-for="(a, i) in alerts" :key="a.profile + '/' + a.model + '/' + i" class="alert-card">
         <span class="dot d-error"></span>
         <strong>{{ a.profile }} × {{ a.model }}</strong>
-        <span class="alert-meta">连续 {{ a.streak }} 轮 · {{ a.task_count > 1 ? ('所属 ' + a.task_count + ' 个任务') : (a.tasks?.[0]?.name || '未命名任务') }}</span>
+        <span class="alert-meta">近窗口失败 {{ a.fail_count }} 次 · {{ a.task_count > 1 ? ('所属 ' + a.task_count + ' 个任务') : (a.tasks?.[0]?.name || '未命名任务') }}</span>
         <router-link class="btn btn-sm" :to="`/sites/${encodeURIComponent(a.profile)}`">进站点 →</router-link>
       </div>
     </div>

--- a/frontend/src/views/__tests__/SitesView.test.js
+++ b/frontend/src/views/__tests__/SitesView.test.js
@@ -10,7 +10,7 @@ vi.mock('../../api', () => ({
   ] })),
   getCellAvailability: vi.fn(() => Promise.resolve({ cells: [] })),
   getActiveAlerts: vi.fn(() => Promise.resolve({ alerts: [
-    { profile: 'siteX', model: 'gpt-4', streak: 3, task_count: 1, tasks: [{ id: 1, name: '巡检A' }] },
+    { profile: 'siteX', model: 'gpt-4', fail_count: 3, task_count: 1, tasks: [{ id: 1, name: '巡检A' }] },
   ] })),
   getSchedules: vi.fn(() => Promise.resolve({ schedules: [
     { id: 9, name: '每日巡检', profile_ids: ['siteX'], status: 'idle' },
@@ -50,7 +50,7 @@ describe('SitesView 合并页', () => {
     const w = mountView();
     await flushPromises();
     expect(w.text()).toContain('siteX × gpt-4');
-    expect(w.text()).toContain('连续 3 轮');
+    expect(w.text()).toContain('近窗口失败 3 次');
   });
 
   it('健康条显示「告警中」计数', async () => {
@@ -68,7 +68,7 @@ describe('SitesView 合并页', () => {
 
   it('告警不带 tasks 字段时不崩溃并回退「未命名任务」', async () => {
     vi.mocked(getActiveAlerts).mockResolvedValueOnce({ alerts: [
-      { profile: 'siteY', model: 'gpt-4o', streak: 2, task_count: 1 },
+      { profile: 'siteY', model: 'gpt-4o', fail_count: 2, task_count: 1 },
     ] });
     const w = mountView();
     await flushPromises();

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -155,7 +155,7 @@ def test_aggregate_active_alerts_merges_by_cell():
     assert len(out) == 1
     cell = out[0]
     assert cell["profile"] == "siteX" and cell["model"] == "gpt-4"
-    assert cell["streak"] == 3
+    assert cell["fail_count"] == 3
     assert cell["task_count"] == 2
     assert {t["id"] for t in cell["tasks"]} == {1, 2}
 
@@ -168,7 +168,7 @@ def test_aggregate_active_alerts_handles_empty_and_legacy():
         {"id": 3, "name": "z", "profile_ids": ["s"], "alert_state": '{"s": {"m": "alerting"}}'},
     ]
     out = aggregate_active_alerts(tasks)
-    assert len(out) == 1 and out[0]["streak"] == 0
+    assert len(out) == 1 and out[0]["fail_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -189,7 +189,7 @@ async def test_active_alerts_endpoint(client):
     alerts = r.json()["alerts"]
     assert len(alerts) == 1
     assert alerts[0]["profile"] == "s" and alerts[0]["model"] == "gpt-4o-mini"
-    assert alerts[0]["streak"] == 2
+    assert alerts[0]["fail_count"] == 2
     assert alerts[0]["task_count"] == 1
 
 

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -9,25 +10,36 @@ from app.db import (
 )
 
 
-async def _seed_task(cells, alert_state=None, enabled=True, notifier_id=None):
-    """cells: [(profile, model, succ, tot)] 落 result 行（run-1）+ 建任务。
-    alert_state: dict 或 None（None=保持默认）。notifier_id: None=新建有效告警器。"""
+def _ts(minutes_ago: int) -> str:
+    return (datetime.now() - timedelta(minutes=minutes_ago)).strftime("%Y%m%d_%H%M%S")
+
+
+async def _seed_task(rounds, alert_state=None, enabled=True, notifier_id=None,
+                     alert_rules=None):
+    """rounds: [[(profile, model, succ, tot), ...], ...]，旧→新，每个内层 list 是一轮的多格。
+    第 i 轮 run_id='run-i'，timestamp 旧→新递增（最后一轮约 5 分钟前，落在默认 1h 窗口内）。
+    返回 (sid, [最后一轮 run_id])，后者作为 _maybe_send_alert 的「本轮」run_ids。"""
     if notifier_id is None:
         notifier_id = await create_notifier(1, "g", "https://open.feishu.cn/x")
     sid = await create_scheduled_task(
         1, "t", ["SiteA"], {}, "interval", "300",
         alert_notifier_id=notifier_id, alert_threshold=90, alert_enabled=enabled,
+        alert_rules=json.dumps(alert_rules) if alert_rules else "",
     )
     if alert_state is not None:
         await update_scheduled_task(sid, alert_state=json.dumps(alert_state))
-    for i, (pf, model, succ, tot) in enumerate(cells):
-        await save_result(
-            user_id=1, test_id=f"r{i}", filename=f"r{i}.json", timestamp="20260609_120000",
-            config_json=json.dumps({"profile_name": pf, "model": model}),
-            summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
-            percentiles_json="{}", run_id="run-1", scheduled_task_id=sid,
-        )
-    return sid
+    n = len(rounds)
+    for ri, cells in enumerate(rounds):
+        ts = _ts(minutes_ago=(n - ri) * 5)
+        for ci, (pf, model, succ, tot) in enumerate(cells):
+            await save_result(
+                user_id=1, test_id=f"r{ri}_{ci}", filename=f"r{ri}_{ci}.json", timestamp=ts,
+                config_json=json.dumps({"profile_name": pf, "model": model}),
+                summary_json=json.dumps({"success_count": succ, "total_requests": tot}),
+                percentiles_json="{}", run_id=f"run-{ri}", scheduled_task_id=sid,
+            )
+    last_run = [f"run-{n - 1}"] if n else ["run-empty"]
+    return sid, last_run
 
 
 def _collector():
@@ -38,18 +50,131 @@ def _collector():
     return sent, fake_send
 
 
+async def _eval(sid, run_ids):
+    row = await get_scheduled_task(sid)
+    await scheduler._maybe_send_alert(sid, row, run_ids)
+
+
+# ---- 告警触发：连续 / 累计 ----
+
 @pytest.mark.asyncio
-async def test_per_cell_alert_only_failing_cell(monkeypatch):
+async def test_consecutive_two_fails_alert(monkeypatch):
+    """连续 2 个坏轮 → 告警（抓硬故障）。"""
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # gpt-4o 已累积 1 次（streak=1），本轮再跌破 → 连续 2 次翻红；claude 正常
-    sid = await _seed_task(
-        [("SiteA", "gpt-4o", 2, 10), ("SiteA", "claude", 10, 10)],
-        alert_state={"SiteA": {"gpt-4o": {"s": "ok", "n": 1}}},
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+    ])
+    await _eval(sid, run)
+    assert len(sent) == 1
+    assert sent[0]["card"]["header"]["template"] == "red"
+    assert "gpt-4o" in str(sent[0])
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"
+
+
+@pytest.mark.asyncio
+async def test_intermittent_three_in_window_alert(monkeypatch):
+    """坏好坏好坏：不连续但窗口内累计 3 个坏轮 → 告警（抓间歇抖动）。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 1, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 1, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+    ])
+    await _eval(sid, run)
+    assert len(sent) == 1
+    assert sent[0]["card"]["header"]["template"] == "red"
+
+
+@pytest.mark.asyncio
+async def test_two_in_window_not_alert(monkeypatch):
+    """窗口内仅 2 个坏轮且不连续 → 容忍，不告警（默认累计阈值 3）。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 1, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 1, 1)],
+    ])
+    await _eval(sid, run)
+    assert sent == []
+
+
+# ---- 冷启动 ----
+
+@pytest.mark.asyncio
+async def test_cold_start_single_round_no_alert(monkeypatch):
+    """只有 1 轮（样本不足）→ 不评估、不告警。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task([[("SiteA", "gpt-4o", 0, 1)]])
+    await _eval(sid, run)
+    assert sent == []
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"]["s"] == "ok"
+
+
+# ---- 恢复：需连续 N 个好轮 ----
+
+@pytest.mark.asyncio
+async def test_recover_needs_two_good(monkeypatch):
+    """告警中，末尾连续 2 个好轮 → 恢复。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task(
+        [
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 1, 1)],
+            [("SiteA", "gpt-4o", 1, 1)],
+        ],
+        alert_state={"SiteA": {"gpt-4o": "alerting"}},
     )
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert len(sent) == 1                       # 只发一条红卡
+    await _eval(sid, run)
+    assert len(sent) == 1
+    assert sent[0]["card"]["header"]["template"] == "green"
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"]["s"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_recover_one_good_not_enough(monkeypatch):
+    """告警中，末尾仅 1 个好轮 → 保持告警，不发恢复卡。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task(
+        [
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 1, 1)],
+        ],
+        alert_state={"SiteA": {"gpt-4o": "alerting"}},
+    )
+    await _eval(sid, run)
+    assert sent == []
+    states = json.loads((await get_scheduled_task(sid))["alert_state"])
+    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"
+
+
+# ---- 多格子：只告警出问题的格子 ----
+
+@pytest.mark.asyncio
+async def test_per_cell_alert_only_failing_cell(monkeypatch):
+    """gpt-4o 连续 2 坏告警；claude 一直好不告警。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1), ("SiteA", "claude", 1, 1)],
+        [("SiteA", "gpt-4o", 0, 1), ("SiteA", "claude", 1, 1)],
+    ])
+    await _eval(sid, run)
+    assert len(sent) == 1
     flat = str(sent[0])
     assert "gpt-4o" in flat and "claude" not in flat
     states = json.loads((await get_scheduled_task(sid))["alert_state"])
@@ -58,17 +183,19 @@ async def test_per_cell_alert_only_failing_cell(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
+async def test_simultaneous_alert_and_recover(monkeypatch):
+    """同轮：gpt-4o 恢复(末尾2好)、claude 新告警(连续2坏) → 两张卡。"""
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # prev: gpt-4o 告警中(旧裸字符串，测兼容)、claude 已累积 1 次；
-    # 本轮 gpt-4o 恢复(100%)、claude 再跌破(10%) → 连续 2 次翻红
-    sid = await _seed_task(
-        [("SiteA", "gpt-4o", 10, 10), ("SiteA", "claude", 1, 10)],
-        alert_state={"SiteA": {"gpt-4o": "alerting", "claude": {"s": "ok", "n": 1}}},
+    sid, run = await _seed_task(
+        [
+            [("SiteA", "gpt-4o", 0, 1), ("SiteA", "claude", 1, 1)],
+            [("SiteA", "gpt-4o", 1, 1), ("SiteA", "claude", 0, 1)],
+            [("SiteA", "gpt-4o", 1, 1), ("SiteA", "claude", 0, 1)],
+        ],
+        alert_state={"SiteA": {"gpt-4o": "alerting"}},
     )
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    await _eval(sid, run)
     assert len(sent) == 2
     cards = {c["card"]["header"]["template"]: str(c) for c in sent}
     assert "claude" in cards["red"] and "gpt-4o" not in cards["red"]
@@ -78,13 +205,54 @@ async def test_per_cell_simultaneous_alert_and_recover(monkeypatch):
     assert states["SiteA"]["claude"]["s"] == "alerting"
 
 
+# ---- 窗口模式：次数 ----
+
+@pytest.mark.asyncio
+async def test_count_window_truncates_old_rounds(monkeypatch):
+    """count 模式 value=3：老的 2 个坏轮被截断，最近 3 轮只 1 坏 → 不告警。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task(
+        [
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 0, 1)],
+            [("SiteA", "gpt-4o", 1, 1)],
+            [("SiteA", "gpt-4o", 1, 1)],
+        ],
+        alert_rules={"mode": "count", "value": 3},
+    )
+    await _eval(sid, run)
+    assert sent == []
+
+
+# ---- 单轮成功率阈值生效（多请求场景）----
+
+@pytest.mark.asyncio
+async def test_threshold_marks_bad_round_with_multi_requests(monkeypatch):
+    """多请求：单轮成功率 8/10=80% < 90% 阈值 → 连续 2 轮记坏 → 告警。"""
+    sent, fake_send = _collector()
+    monkeypatch.setattr(notifier, "send_webhook", fake_send)
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 8, 10)],
+        [("SiteA", "gpt-4o", 8, 10)],
+    ])
+    await _eval(sid, run)
+    assert len(sent) == 1
+    assert sent[0]["card"]["header"]["template"] == "red"
+
+
+# ---- 全好 / 关闭 / 告警器缺失 ----
+
 @pytest.mark.asyncio
 async def test_no_alert_when_all_ok(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 10, 10)])
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 1, 1)],
+        [("SiteA", "gpt-4o", 1, 1)],
+    ])
+    await _eval(sid, run)
     assert sent == []
 
 
@@ -92,9 +260,11 @@ async def test_no_alert_when_all_ok(monkeypatch):
 async def test_disabled_no_alert(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], enabled=False)
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+    ], enabled=False)
+    await _eval(sid, run)
     assert sent == []
 
 
@@ -102,9 +272,11 @@ async def test_disabled_no_alert(monkeypatch):
 async def test_skips_when_notifier_id_zero(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=0)
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+    ], notifier_id=0)
+    await _eval(sid, run)
     assert sent == []
 
 
@@ -112,9 +284,11 @@ async def test_skips_when_notifier_id_zero(monkeypatch):
 async def test_skips_when_notifier_missing(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 0, 10)], notifier_id=999999)
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    sid, run = await _seed_task([
+        [("SiteA", "gpt-4o", 0, 1)],
+        [("SiteA", "gpt-4o", 0, 1)],
+    ], notifier_id=999999)
+    await _eval(sid, run)
     assert sent == []
 
 
@@ -122,70 +296,21 @@ async def test_skips_when_notifier_missing(monkeypatch):
 async def test_no_results_no_alert(monkeypatch):
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([])   # 不造 result 行
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-empty"])
+    sid, _ = await _seed_task([])
+    await _eval(sid, ["run-empty"])
     assert sent == []
 
 
 @pytest.mark.asyncio
-async def test_zero_total_cell_skipped_preserves_state(monkeypatch):
+async def test_zero_total_round_preserves_alerting(monkeypatch):
+    """本轮 total=0（未发出请求）且无历史有效轮 → 保留旧 alerting 态、不翻转。"""
     sent, fake_send = _collector()
     monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    # gpt-4o 本轮 total=0（未发出），claude 正常；prev gpt-4o=alerting → 保留
-    sid = await _seed_task(
-        [("SiteA", "gpt-4o", 0, 0), ("SiteA", "claude", 10, 10)],
+    sid, run = await _seed_task(
+        [[("SiteA", "gpt-4o", 0, 0)]],
         alert_state={"SiteA": {"gpt-4o": "alerting"}},
     )
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert sent == []                          # 无翻转
-    states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"   # 保留旧态
-    assert states["SiteA"]["claude"]["s"] == "ok"
-
-
-@pytest.mark.asyncio
-async def test_single_abnormal_round_does_not_alert(monkeypatch):
-    # 第一次跌破：不发卡，仅累积 streak=1（防抖）
-    sent, fake_send = _collector()
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task([("SiteA", "gpt-4o", 2, 10)])
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
+    await _eval(sid, run)
     assert sent == []
     states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 1}
-
-
-@pytest.mark.asyncio
-async def test_recovery_after_alert_single_good_round(monkeypatch):
-    # 已告警，一次回到阈值即报恢复并清零
-    sent, fake_send = _collector()
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task(
-        [("SiteA", "gpt-4o", 10, 10)],
-        alert_state={"SiteA": {"gpt-4o": {"s": "alerting", "n": 2}}},
-    )
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert len(sent) == 1
-    assert sent[0]["card"]["header"]["template"] == "green"
-    states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 0}
-
-
-@pytest.mark.asyncio
-async def test_streak_resets_on_good_round(monkeypatch):
-    # 累积中(streak=1)遇到一次正常 → 清零，不告警
-    sent, fake_send = _collector()
-    monkeypatch.setattr(notifier, "send_webhook", fake_send)
-    sid = await _seed_task(
-        [("SiteA", "gpt-4o", 10, 10)],
-        alert_state={"SiteA": {"gpt-4o": {"s": "ok", "n": 1}}},
-    )
-    row = await get_scheduled_task(sid)
-    await scheduler._maybe_send_alert(sid, row, ["run-1"])
-    assert sent == []
-    states = json.loads((await get_scheduled_task(sid))["alert_state"])
-    assert states["SiteA"]["gpt-4o"] == {"s": "ok", "n": 0}
+    assert states["SiteA"]["gpt-4o"]["s"] == "alerting"

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -3,48 +3,84 @@ import json
 import pytest
 
 from app import notifier
-from app.notifier import build_feishu_card, evaluate_alert, is_allowed_webhook
+from app.notifier import (
+    build_feishu_card, evaluate_window, is_allowed_webhook,
+    DEFAULT_ALERT_RULES, _load_rules,
+)
+
+R = DEFAULT_ALERT_RULES   # 默认 fail_consecutive=2, fail_in_window=3, recover_consecutive=2
 
 
-def test_first_abnormal_no_alert_increments_streak():
-    # 第一次低于阈值：不告警，仅累积 streak
-    assert evaluate_alert("ok", 0, 72.0, 90) == ("ok", 1, None)
+# ---- evaluate_window：滑动窗口失败计数判定 ----
+
+def test_cold_start_under_min_samples_no_action():
+    # 样本不足（<2）：保留旧态，不动作
+    assert evaluate_window([True], "ok", R) == ("ok", None, 1)
+    assert evaluate_window([], "ok", R) == ("ok", None, 0)
 
 
-def test_second_consecutive_abnormal_fires():
-    # 连续第二次低于阈值：翻红告警
-    assert evaluate_alert("ok", 1, 72.0, 90) == ("alerting", 2, "alert")
+def test_consecutive_two_fails_alert():
+    assert evaluate_window([True, True], "ok", R) == ("alerting", "alert", 2)
 
 
-def test_no_repeat_while_abnormal():
-    # 已告警继续异常：保持，不重复发
-    assert evaluate_alert("alerting", 2, 50.0, 90) == ("alerting", 2, None)
+def test_intermittent_three_in_window_alert():
+    # 坏好坏好坏：不连续但累计 3 → 告警
+    assert evaluate_window([True, False, True, False, True], "ok", R) == ("alerting", "alert", 3)
 
 
-def test_recover_on_abnormal_to_ok():
-    # 告警中一次回到阈值即报恢复，并清零
-    assert evaluate_alert("alerting", 2, 95.0, 90) == ("ok", 0, "recover")
+def test_two_non_consecutive_not_alert():
+    # 累计 2 个且不连续：容忍，不告警
+    assert evaluate_window([True, False, True, False], "ok", R) == ("ok", None, 2)
 
 
-def test_single_normal_resets_streak():
-    # 累积中(streak=1)遇到一次正常：清零，不告警
-    assert evaluate_alert("ok", 1, 99.0, 90) == ("ok", 0, None)
+def test_keeps_alerting_no_repeat():
+    assert evaluate_window([True, True], "alerting", R) == ("alerting", None, 2)
 
 
-def test_no_action_while_ok():
-    assert evaluate_alert("ok", 0, 99.0, 90) == ("ok", 0, None)
+def test_recover_needs_two_consecutive_good():
+    assert evaluate_window([True, True, False, False], "alerting", R) == ("ok", "recover", 2)
 
 
-def test_threshold_boundary_is_normal():
-    # 等于阈值不算异常，且清零
-    assert evaluate_alert("ok", 1, 90.0, 90) == ("ok", 0, None)
+def test_recover_one_good_not_enough():
+    assert evaluate_window([True, True, False], "alerting", R) == ("alerting", None, 2)
 
 
-def test_custom_fail_needed_three():
-    # fail_needed=3：第 2 次仍不发，第 3 次才发
-    assert evaluate_alert("ok", 1, 50.0, 90, fail_needed=3) == ("ok", 2, None)
-    assert evaluate_alert("ok", 2, 50.0, 90, fail_needed=3) == ("alerting", 3, "alert")
+def test_all_good_no_action():
+    assert evaluate_window([False, False], "ok", R) == ("ok", None, 0)
 
+
+def test_custom_rules():
+    rules = {"fail_consecutive": 3, "fail_in_window": 99, "recover_consecutive": 1}
+    assert evaluate_window([True, True], "ok", rules) == ("ok", None, 2)
+    assert evaluate_window([True, True, True], "ok", rules) == ("alerting", "alert", 3)
+    # recover_consecutive=1：一次好即恢复
+    assert evaluate_window([True, True, False], "alerting", rules) == ("ok", "recover", 2)
+
+
+# ---- _load_rules ----
+
+def test_load_rules_default_on_empty():
+    assert _load_rules("") == DEFAULT_ALERT_RULES
+    assert _load_rules(None) == DEFAULT_ALERT_RULES
+
+
+def test_load_rules_merges_partial():
+    r = _load_rules('{"mode": "count", "value": 20}')
+    assert r["mode"] == "count" and r["value"] == 20
+    assert r["fail_consecutive"] == 2 and r["fail_in_window"] == 3   # 缺省补全
+
+
+def test_load_rules_garbage_falls_back():
+    assert _load_rules("not json") == DEFAULT_ALERT_RULES
+    assert _load_rules("[1,2]") == DEFAULT_ALERT_RULES
+
+
+def test_load_rules_accepts_dict():
+    r = _load_rules({"value": 6})
+    assert r["value"] == 6 and r["mode"] == "time"
+
+
+# ---- _cell_state（解析不变，n 语义=窗口失败数）----
 
 def test_cell_state_legacy_string():
     from app.notifier import _cell_state
@@ -55,7 +91,7 @@ def test_cell_state_legacy_string():
 def test_cell_state_new_dict():
     from app.notifier import _cell_state
     assert _cell_state({"s": "ok", "n": 1}) == ("ok", 1)
-    assert _cell_state({"s": "alerting", "n": 2}) == ("alerting", 2)
+    assert _cell_state({"s": "alerting", "n": 3}) == ("alerting", 3)
 
 
 def test_cell_state_missing_or_garbage():
@@ -65,6 +101,8 @@ def test_cell_state_missing_or_garbage():
     assert _cell_state("weird") == ("ok", 0)
     assert _cell_state({"s": "weird", "n": "x"}) == ("ok", 0)
 
+
+# ---- SSRF 白名单 ----
 
 def test_feishu_https_allowed():
     assert is_allowed_webhook("https://open.feishu.cn/open-apis/bot/v2/hook/xxx") is True
@@ -94,9 +132,11 @@ def test_empty_rejected():
     assert is_allowed_webhook("") is False
 
 
+# ---- 飞书卡片（cells 为 (profile, model, fail_count, total)）----
+
 def test_alert_card_red_header():
     card = build_feishu_card("alert", "主力渠道",
-                             [("OpenAI-A", "gpt-4o", 72.0), ("OpenAI-B", "claude", 65.0)],
+                             [("OpenAI-A", "gpt-4o", 3, 12), ("OpenAI-B", "claude", 5, 12)],
                              90, "2026-06-09 10:30")
     assert card["msg_type"] == "interactive"
     assert card["card"]["config"]["wide_screen_mode"] is True
@@ -105,24 +145,24 @@ def test_alert_card_red_header():
     assert "告警" in title and "主力渠道" in title and "2 个异常" in title
     assert "OpenAI-A/gpt-4o" in title          # 首个异常的站点×模型进标题
     flat = str(card)
-    assert "OpenAI-A" in flat and "gpt-4o" in flat and "72.0%" in flat
-    assert "OpenAI-B" in flat and "claude" in flat and "65.0%" in flat
-    assert "低于阈值 90%" in flat            # 汇总行带阈值
+    assert "OpenAI-A" in flat and "gpt-4o" in flat and "3/12" in flat
+    assert "OpenAI-B" in flat and "claude" in flat and "5/12" in flat
+    assert "< 90%" in flat                      # 汇总行带单轮健康线
 
 
 def test_recover_card_green_header():
     card = build_feishu_card("recover", "主力渠道",
-                             [("OpenAI-A", "gpt-4o", 95.0)], 90, "2026-06-09 10:30")
+                             [("OpenAI-A", "gpt-4o", 0, 12)], 90, "2026-06-09 10:30")
     assert card["card"]["header"]["template"] == "green"
     title = card["card"]["header"]["title"]["content"]
     assert "恢复" in title and "主力渠道" in title and "1 个" in title
     assert "OpenAI-A/gpt-4o" in title
     flat = str(card)
-    assert "OpenAI-A" in flat and "gpt-4o" in flat and "95.0%" in flat
+    assert "OpenAI-A" in flat and "gpt-4o" in flat
 
 
 def test_card_title_handles_empty_task_name():
-    card = build_feishu_card("alert", "", [("S", "m", 50.0)], 90, "t")
+    card = build_feishu_card("alert", "", [("S", "m", 2, 5)], 90, "t")
     title = card["card"]["header"]["title"]["content"]
     assert title.startswith("🔴 拨测告警 · S/m")   # 站点×模型进标题
     assert "1 个异常" in title
@@ -189,24 +229,21 @@ def test_load_alert_states_non_dict_json():
 
 
 def test_feishu_card_includes_link_when_base_url_given():
-    from app.notifier import build_feishu_card
-    card = build_feishu_card("alert", "任务A", [("siteX", "gpt-4", 0.0)],
+    card = build_feishu_card("alert", "任务A", [("siteX", "gpt-4", 3, 12)],
                              90, "2026-06-14 10:00:00", base_url="https://app.aitokenperf.com")
     blob = json.dumps(card, ensure_ascii=False)
     assert "https://app.aitokenperf.com/sites/siteX" in blob
 
 
 def test_feishu_card_no_link_when_base_url_absent():
-    from app.notifier import build_feishu_card
-    card = build_feishu_card("alert", "任务A", [("siteX", "gpt-4", 0.0)],
+    card = build_feishu_card("alert", "任务A", [("siteX", "gpt-4", 3, 12)],
                              90, "2026-06-14 10:00:00")
     blob = json.dumps(card, ensure_ascii=False)
     assert "/sites/" not in blob
 
 
 def test_feishu_card_link_encodes_special_chars():
-    from app.notifier import build_feishu_card
-    card = build_feishu_card("alert", "", [("site/A?x=1", "m", 0.0)],
+    card = build_feishu_card("alert", "", [("site/A?x=1", "m", 1, 12)],
                              90, "2026-06-14 00:00:00", base_url="https://h.example.com")
     blob = json.dumps(card, ensure_ascii=False)
     assert "site%2FA%3Fx%3D1" in blob


### PR DESCRIPTION
## Summary

把定时拨测告警从「逐轮 `succ/tot` 成功率 + 连续2次低于阈值」改为「**站点×模型 滑动窗口失败计数**」，修复两个根本问题：

1. **阈值是摆设**：监控默认每轮每模型只发 1 个请求，单轮成功率只可能 0% 或 100%，`alert_threshold` 退化为「这次挂没挂」，配 90/50/99 结果一样。
2. **告警与看板口径割裂**：健康看板按时间窗口聚合可用性，而告警只看「最近连续几轮挂没挂」，两者对不上。

### 新判定规则（站点×模型，OR）
- 单轮健康线 = `alert_threshold`：单次成功率 < 阈值 → 记一次「坏轮」（1 请求时即这次成没成功；多请求时阈值恢复意义）
- **连续 2 次坏轮** → 告警（抓硬故障，约 10 分钟报出）
- **窗口内累计 3 次坏轮** → 告警（抓间歇抖动，容忍偶发 1 次）
- **连续 2 次好轮** → 恢复
- 窗口支持 `time`(默认最近 1h) / `count`(默认最近 10 次) 两模式
- 冷启动样本 < 2 不评估，避免误报

### 改动点
- `app/db.py`：新增 `alert_rules` JSON 列（建表 + SQLite/PG 迁移 + create/update 透传）；新增 `get_task_window_rounds_by_cell()` 按 `scheduled_task_id` 实时查窗口，按 `(profile,model,run_id)` 聚合成「轮」
- `app/notifier.py`：`evaluate_alert` → `evaluate_window`（窗口失败计数）；新增 `DEFAULT_ALERT_RULES`/`_load_rules`；`alert_state` 单格 `n` 语义改为窗口失败数；`aggregate_active_alerts` 字段 `streak`→`fail_count`；飞书卡片文案改为「窗口内失败 N/总 次」
- `app/scheduler.py`：`_maybe_send_alert` 接窗口查询，仅评估本轮出现的格子，保留本轮缺席但仍告警的旧格子
- `app/server.py`：`_extract_alert_fields` 校验并透传 `alert_rules`
- 前端 `SiteSchedulesTab.vue`：告警区暴露窗口模式/值、连续失败、累计失败、恢复连续好轮，给好默认；阈值文案改为「单次拨测成功率低于此记为一次失败」。`SitesView.vue` 告警卡 `streak`→`fail_count`

Closes #89

## Test plan
- [x] 后端：`test_alert_scheduler.py` / `test_notifier.py` / `test_alert_api.py` 全过（65 passed）
  - 连续 2 坏告警、间歇累计 3 坏告警、2 坏不连续不告警、冷启动不评估、连续 2 好恢复、1 好不够恢复、count 窗口截断、多请求阈值生效、多格子只告警异常格、同轮告警+恢复并发
- [x] 前端：vitest 60 passed + `bun run build` 通过
- [ ] 人工验证：新建/编辑监控任务能配置窗口规则并回填；触发后飞书卡片文案正确
