### PR TITLE
feat: 告警卡片按站点分组每模型一行，恢复卡显示连续正常轮数

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -161,8 +161,9 @@ def build_feishu_card(kind: str, task_name: str,
                       cells: list, threshold: int, ts: str,
                       base_url: str = "") -> dict:
     """构造飞书自定义机器人 interactive 卡片。kind ∈ {'alert','recover'}。
-    cells: [(profile, model, fail_count, total), ...] —— 本轮新翻转的格子，
-           fail_count=窗口内坏轮数，total=窗口内有效轮数。
+    cells: [(profile, model, metric, total), ...] —— 本轮新翻转的格子，total=窗口内有效轮数。
+           alert  时 metric=窗口内坏轮数；recover 时 metric=末尾连续正常轮数。
+    排版：按站点分组，站点名只写一次，组内每个模型占一行，手机上扫读最快。
     threshold: 单轮健康线（单次拨测成功率 < threshold% 记为一次失败）。
     base_url: 公开访问基址（如 https://app.aitokenperf.com），空则不加跳转按钮。"""
     n = len(cells)
@@ -170,10 +171,12 @@ def build_feishu_card(kind: str, task_name: str,
     label = f" · {task_name}" if task_name else ""
     if kind == "recover":
         template = color = "green"
+        icon = "✅"
         title = f"✅ 已恢复{cell}{label}（{n} 个）"
         summary = f"以下 {n} 个站点/模型拨测已恢复稳定"
     else:
         template = color = "red"
+        icon = "🔴"
         title = f"🔴 拨测告警{cell}{label}（{n} 个异常）"
         summary = (f"以下 {n} 个站点/模型近窗口内拨测失败次数超限"
                    f"（单次成功率 < {threshold}% 记为一次失败）")
@@ -181,13 +184,24 @@ def build_feishu_card(kind: str, task_name: str,
         {"tag": "div", "text": {"tag": "lark_md", "content": f"**任务**：{task_name}"}},
         {"tag": "div", "text": {"tag": "lark_md", "content": summary}},
     ]
-    for profile, model, fail_count, total in cells:
-        elements.append({"tag": "div", "fields": [
-            {"is_short": True, "text": {"tag": "lark_md", "content": f"**站点**\n{profile}"}},
-            {"is_short": True, "text": {"tag": "lark_md", "content": f"**模型**\n{model}"}},
-            {"is_short": True, "text": {"tag": "lark_md",
-                "content": f"**失败**\n<font color='{color}'>{fail_count}/{total} 次</font>"}},
-        ]})
+    # 按站点分组（保持 cells 原有顺序），站点名一行 + 组内各模型逐行
+    grouped: list = []          # [(profile, [(model, metric, total), ...]), ...]
+    index: dict = {}
+    for profile, model, metric, total in cells:
+        if profile not in index:
+            index[profile] = len(grouped)
+            grouped.append((profile, []))
+        grouped[index[profile]][1].append((model, metric, total))
+    for profile, rows in grouped:
+        lines = [f"**站点 {profile}**"]
+        for model, metric, total in rows:
+            if kind == "recover":
+                stat = f"已连续 <font color='{color}'>{metric}</font> 轮正常"
+            else:
+                stat = f"失败 <font color='{color}'>{metric}/{total}</font> 轮"
+            lines.append(f"{icon} {model} · {stat}")
+        elements.append({"tag": "div",
+                         "text": {"tag": "lark_md", "content": "\n".join(lines)}})
     if base_url and cells:
         base_url = base_url.rstrip("/")
         site = quote(str(cells[0][0]), safe="")

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -270,7 +270,13 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
         if action == "alert":
             alerts.append((profile, model, fail_count, total))
         elif action == "recover":
-            recovers.append((profile, model, fail_count, total))
+            # 恢复卡展示末尾连续正常轮数（坏轮序列尾部连续 False 的个数）
+            consec_good = 0
+            for b in reversed(rounds):
+                if b:
+                    break
+                consec_good += 1
+            recovers.append((profile, model, consec_good, total))
 
     # 本轮未出现但仍在告警的旧格子：保留状态，避免临时跳过（如容量不足）丢失告警
     for profile, models in prev.items():

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -132,7 +132,7 @@ def test_empty_rejected():
     assert is_allowed_webhook("") is False
 
 
-# ---- 飞书卡片（cells 为 (profile, model, fail_count, total)）----
+# ---- 飞书卡片（cells 为 (profile, model, metric, total)）----
 
 def test_alert_card_red_header():
     card = build_feishu_card("alert", "主力渠道",
@@ -150,15 +150,29 @@ def test_alert_card_red_header():
     assert "< 90%" in flat                      # 汇总行带单轮健康线
 
 
+def test_alert_card_groups_by_site():
+    # 同站点多模型：站点名只出现一次，各模型分别成行
+    card = build_feishu_card("alert", "hao",
+                             [("hao.ai", "claude-opus-4-8", 5, 12),
+                              ("hao.ai", "claude-sonnet-4-6", 4, 13)],
+                             90, "t")
+    flat = str(card)
+    assert flat.count("站点 hao.ai") == 1       # 站点名只写一次
+    assert "claude-opus-4-8 · 失败" in flat and "5/12" in flat
+    assert "claude-sonnet-4-6 · 失败" in flat and "4/13" in flat
+
+
 def test_recover_card_green_header():
     card = build_feishu_card("recover", "主力渠道",
-                             [("OpenAI-A", "gpt-4o", 0, 12)], 90, "2026-06-09 10:30")
+                             [("OpenAI-A", "gpt-4o", 2, 12)], 90, "2026-06-09 10:30")
     assert card["card"]["header"]["template"] == "green"
     title = card["card"]["header"]["title"]["content"]
     assert "恢复" in title and "主力渠道" in title and "1 个" in title
     assert "OpenAI-A/gpt-4o" in title
     flat = str(card)
     assert "OpenAI-A" in flat and "gpt-4o" in flat
+    assert "已连续" in flat and "轮正常" in flat   # 恢复卡显示连续正常轮数，不显示失败比例
+    assert "失败" not in flat
 
 
 def test_card_title_handles_empty_task_name():


### PR DESCRIPTION
## 背景

飞书告警/恢复卡片每个异常格子用 3 个竖排 `is_short` 字段（站点/模型/失败）堆叠，导致：一个异常占大半屏、站点名与标签每格重复、扫读慢；且绿色「已恢复」卡却显示「失败 5/12 次」，语义矛盾。

## 改动

正文改为**按站点分组 + 每模型一行**（方案与使用者确认）：

```
站点 hao.ai
🔴 claude-opus-4-8 · 失败 5/12 轮
🔴 claude-sonnet-4-6 · 失败 4/13 轮
```

恢复卡文案改为**「已连续 N 轮正常」**，不再显示失败比例。

- `app/notifier.py` `build_feishu_card`：按站点 group，cells 第 3 元素语义统一为 metric（alert=坏轮数 / recover=连续正常轮数）
- `app/scheduler.py`：recover 分支计算末尾连续正常轮数传入
- `tests/test_notifier.py`：新增分组断言、恢复卡文案断言

## 测试

`pytest tests/test_notifier.py tests/test_alert_scheduler.py tests/test_schedule_notify.py` → 54 passed

Closes #94