### PR TITLE
fix: 告警恢复改为对称迟滞，消除恢复↔告警反复横跳

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -18,7 +18,8 @@ FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
 #   mode='time'  → 取最近 value 小时内的轮；'count' → 每格取最近 value 轮
 #   fail_consecutive   末尾连续坏轮 ≥ 此值 → 告警（抓硬故障）
 #   fail_in_window     窗口内累计坏轮 ≥ 此值 → 告警（抓间歇抖动，容忍偶发）
-#   recover_consecutive 告警中末尾连续好轮 ≥ 此值 → 恢复
+#   recover_consecutive 告警中末尾连续好轮 ≥ 此值 且 窗口内坏轮 < fail_in_window → 恢复
+#     （对称迟滞：触发看窗口整体健康度，恢复也要等窗口退烧，避免单次抖动反复横跳）
 DEFAULT_ALERT_RULES = {
     "mode": "time", "value": 1,
     "fail_consecutive": 2, "fail_in_window": 3, "recover_consecutive": 2,
@@ -70,8 +71,10 @@ def evaluate_window(rounds: list, prev_state: str,
             break
 
     if prev_state == ALERT_ALERTING:
-        if consec_good >= rc:
-            return ALERT_OK, "recover", fail_count          # 连续好轮够 → 恢复
+        # 对称迟滞：连续好轮够 且 窗口已退烧（累计坏轮 < fw）才恢复，
+        # 否则保持告警——避免老失败还压在窗口里时被单次抖动反复弹回。
+        if consec_good >= rc and fail_count < fw:
+            return ALERT_OK, "recover", fail_count          # 连续好 + 窗口退烧 → 恢复
         return ALERT_ALERTING, None, fail_count             # 保持告警，不重复发
     if consec_fail >= fc or fail_count >= fw:
         return ALERT_ALERTING, "alert", fail_count          # 连续坏 或 累计坏 → 告警

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -45,6 +45,22 @@ def test_recover_one_good_not_enough():
     assert evaluate_window([True, True, False], "alerting", R) == ("alerting", None, 2)
 
 
+def test_recover_waits_for_window_to_drain():
+    # 对称迟滞：连续好够了，但窗口内坏轮仍 ≥ 告警阈值 → 不恢复，避免被单次抖动反复弹回
+    rules = {"fail_consecutive": 2, "fail_in_window": 2, "recover_consecutive": 2}
+    # 老失败还压在窗口里：累计=2≥fw，虽连续2正常也保持告警
+    assert evaluate_window([True, True, False, False], "alerting", rules) == ("alerting", None, 2)
+    # 老失败滑出后累计回落到 <fw，且连续2正常 → 这才恢复
+    assert evaluate_window([True, False, False], "alerting", rules) == ("ok", "recover", 1)
+
+
+def test_no_reflap_after_window_dirty():
+    # 用户场景：窗口里留着老失败时，单次新抖动不应让「刚恢复→又告警」来回弹。
+    # 对称迟滞下根本不会先恢复，所以始终保持告警，不产生噪音。
+    rules = {"fail_consecutive": 2, "fail_in_window": 2, "recover_consecutive": 2}
+    assert evaluate_window([True, True, False, False, True], "alerting", rules) == ("alerting", None, 3)
+
+
 def test_all_good_no_action():
     assert evaluate_window([False, False], "ok", R) == ("ok", None, 0)
 


### PR DESCRIPTION
## 问题

触发告警看「窗口整体健康度」（累计坏轮≥阈值），但恢复只看「末尾连续N次正常」——两端不对称。恢复只改状态、不清窗口里的老失败，于是恢复后单次新抖动就能把累计数顶回阈值再次告警，形成反复横跳（详见 #96）。

## 改动

`evaluate_window` 恢复分支加一个条件：

```python
if consec_good >= rc and fail_count < fw:   # 连续好 + 窗口退烧才恢复
```

一旦告警就保持告警，直到窗口里老失败真正滑出、整体退烧到健康线下才报一次「已恢复」；告警期间任何单次抖动都不会弹回。全程只 1 告警 + 1 恢复。

- 兼容：只用「连续N次」告警（fail_in_window 设很大）的配置不受影响，恢复点 fail_count 一般已 < fw
- 代价：「已恢复」通知稍晚（要等窗口真干净），更诚实

## 测试

新增 `test_recover_waits_for_window_to_drain`、`test_no_reflap_after_window_dirty`；原有 recover 测试全部沿用通过。
`pytest tests/test_notifier.py tests/test_alert_scheduler.py tests/test_schedule_notify.py` → 55 passed

Closes #96