### PR TITLE
feat: 告警窗口支持「分钟」模式 + 默认 30 分钟 + 迁移线上旧 1 小时窗口

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -944,16 +944,19 @@ async def get_task_window_rounds_by_cell(
 
     一轮 = 同一 run_id 内该格所有并发档聚合后的 (success, total)；
     bad = 该轮成功率 < threshold（total==0 的轮不计入序列）。
-    mode='time': 取最近 value 小时内的轮；mode='count': 每格取最近 value 轮。
+    mode='time': 取最近 value 小时内的轮；'minute': 最近 value 分钟内；'count': 每格取最近 value 轮。
     返回 {(profile, model): [bad_bool, ...]}（按轮代表时间旧→新）。
     分组口径与 get_run_success_rate_by_cell 一致（profile_name 列；config.model 缺失归 '-'）。"""
     from datetime import datetime, timedelta
     params: dict = {"tid": task_id}
     sql = ("SELECT profile_name, config_json, summary_json, run_id, timestamp "
            "FROM results WHERE scheduled_task_id = :tid")
-    if mode == "time":
-        window_h = value if (value and value > 0) else 1
-        cutoff = (datetime.now() - timedelta(hours=window_h)).strftime("%Y%m%d_%H%M%S")
+    if mode in ("time", "minute"):
+        if mode == "minute":
+            delta = timedelta(minutes=value if (value and value > 0) else 30)
+        else:
+            delta = timedelta(hours=value if (value and value > 0) else 1)
+        cutoff = (datetime.now() - delta).strftime("%Y%m%d_%H%M%S")
         sql += " AND timestamp >= :cutoff"
         params["cutoff"] = cutoff
     async with engine.connect() as conn:

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -15,12 +15,13 @@ ALERT_ALERTING = "alerting"
 FEISHU_ALLOWED_HOSTS = {"open.feishu.cn", "open.larksuite.com"}
 
 # 滑动窗口告警默认规则：
-#   mode='time'  → 取最近 value 小时内的轮；'count' → 每格取最近 value 轮
+#   mode='time' → 最近 value 小时；'minute' → 最近 value 分钟；'count' → 每格取最近 value 轮
 #   fail_consecutive   末尾连续坏轮 ≥ 此值 → 告警（抓硬故障）
 #   fail_in_window     窗口内累计坏轮 ≥ 此值 → 告警（抓间歇抖动，容忍偶发）
 #   recover_consecutive 告警中末尾连续好轮 ≥ 此值 → 恢复
+# 默认 30 分钟窗口：与拨测间隔解耦，改频率不影响窗口时长。
 DEFAULT_ALERT_RULES = {
-    "mode": "time", "value": 1,
+    "mode": "minute", "value": 30,
     "fail_consecutive": 2, "fail_in_window": 3, "recover_consecutive": 2,
 }
 _MIN_SAMPLES = 2   # 窗口内有效轮数不足则视为冷启动，不评估

--- a/frontend/src/components/SiteSchedulesTab.vue
+++ b/frontend/src/components/SiteSchedulesTab.vue
@@ -125,13 +125,14 @@
               <label class="form-label">告警窗口</label>
               <div style="display:flex;gap:8px;align-items:center">
                 <select class="form-input" v-model="createForm.alert_rules.mode" style="width:auto;flex:0 0 auto">
+                  <option value="minute">最近 N 分钟</option>
                   <option value="time">最近 N 小时</option>
                   <option value="count">最近 N 次</option>
                 </select>
                 <input class="form-input" type="number" v-model.number="createForm.alert_rules.value" min="1" style="width:90px">
-                <span class="form-hint" style="margin:0">{{ createForm.alert_rules.mode === 'time' ? '小时' : '次' }}</span>
+                <span class="form-hint" style="margin:0">{{ unitLabel(createForm.alert_rules.mode) }}</span>
               </div>
-              <div class="form-hint">在此窗口内统计失败次数（5 分钟一拨时，1 小时 ≈ 12 次）</div>
+              <div class="form-hint">在此窗口内统计失败次数；窗口越大，恢复通知越慢（按时间的窗口约等于「最长卡在告警」的时长）</div>
             </div>
             <div class="form-group">
               <label class="form-label">连续失败几次告警</label>
@@ -352,13 +353,14 @@
             <label class="form-label">告警窗口</label>
             <div style="display:flex;gap:8px;align-items:center">
               <select class="form-input" v-model="editForm.alert_rules.mode" style="width:auto;flex:0 0 auto">
+                <option value="minute">最近 N 分钟</option>
                 <option value="time">最近 N 小时</option>
                 <option value="count">最近 N 次</option>
               </select>
               <input class="form-input" type="number" v-model.number="editForm.alert_rules.value" min="1" style="width:90px">
-              <span class="form-hint" style="margin:0">{{ editForm.alert_rules.mode === 'time' ? '小时' : '次' }}</span>
+              <span class="form-hint" style="margin:0">{{ unitLabel(editForm.alert_rules.mode) }}</span>
             </div>
-            <div class="form-hint">在此窗口内统计失败次数（5 分钟一拨时，1 小时 ≈ 12 次）</div>
+            <div class="form-hint">在此窗口内统计失败次数；窗口越大，恢复通知越慢（按时间的窗口约等于「最长卡在告警」的时长）</div>
           </div>
           <div class="form-group">
             <label class="form-label">连续失败几次告警</label>
@@ -469,7 +471,12 @@ function defaultCreateForm() {
 
 // 滑动窗口告警默认规则；与后端 notifier.DEFAULT_ALERT_RULES 保持一致
 function defaultAlertRules() {
-  return { mode: 'time', value: 1, fail_consecutive: 2, fail_in_window: 3, recover_consecutive: 2 };
+  return { mode: 'minute', value: 30, fail_consecutive: 2, fail_in_window: 3, recover_consecutive: 2 };
+}
+
+// 窗口模式 → 单位文案
+function unitLabel(mode) {
+  return mode === 'minute' ? '分钟' : mode === 'time' ? '小时' : '次';
 }
 
 // 后端 alert_rules 存为 JSON 字符串；解析并补全缺省字段，非法回退默认

--- a/scripts/migrate_alert_window_30min.py
+++ b/scripts/migrate_alert_window_30min.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""一次性迁移：把旧的「1 小时」告警窗口统一改为「30 分钟」。
+
+背景见 issue #98。默认窗口由 小时/1 改为 分钟/30 后，存量任务里显式写着旧窗口的需要刷一遍：
+  - mode='count' value=12  （5 分钟一拨 × 12 = 1 小时的写法）
+  - mode='time'  value=1   （老默认 1 小时）
+统一改成 mode='minute' value=30。其余字段（fail_* / recover_*）保持不变。
+空 alert_rules 走新默认自动变 30 分钟，无需处理。
+
+幂等：再次运行不会有可迁移项。alert_rules 是纯 TEXT JSON，UPDATE 走参数绑定，
+sqlite / Postgres 通用。
+"""
+
+import asyncio
+import json
+
+import app.config  # noqa: F401  —— 触发 DB 配置加载
+from sqlalchemy import text
+
+from app.db import engine
+
+# 视为「旧 1 小时窗口」的写法 → 一律改为 minute/30
+_OLD_ONE_HOUR = {("count", 12), ("time", 1)}
+_NEW = {"mode": "minute", "value": 30}
+
+
+def _migrate_rules(raw: str):
+    """返回迁移后的 JSON 字符串；无需迁移则返回 None。"""
+    if not raw:
+        return None
+    try:
+        rules = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(rules, dict):
+        return None
+    key = (rules.get("mode"), rules.get("value"))
+    if key not in _OLD_ONE_HOUR:
+        return None
+    rules = {**rules, **_NEW}
+    return json.dumps(rules, ensure_ascii=False)
+
+
+async def main():
+    print("alert window migration: 旧 1 小时窗口 → 30 分钟")
+    changed = 0
+    async with engine.begin() as conn:
+        cur = await conn.execute(
+            text("SELECT id, name, alert_rules FROM scheduled_tasks"))
+        rows = cur.fetchall()
+        for task_id, name, raw in rows:
+            new_raw = _migrate_rules(raw)
+            if new_raw is None:
+                continue
+            await conn.execute(
+                text("UPDATE scheduled_tasks SET alert_rules=:r WHERE id=:id"),
+                {"r": new_raw, "id": task_id})
+            changed += 1
+            print(f"  #{task_id} {name!r}: {raw} → {new_raw}")
+    print(f"done. 共迁移 {changed} 个任务。")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_alert_scheduler.py
+++ b/tests/test_alert_scheduler.py
@@ -55,6 +55,20 @@ async def _eval(sid, run_ids):
     await scheduler._maybe_send_alert(sid, row, run_ids)
 
 
+# ---- 窗口模式：分钟 ----
+
+@pytest.mark.asyncio
+async def test_window_minute_mode_filters_by_minutes():
+    """mode='minute'：按分钟裁窗口（5 轮分别在 25/20/15/10/5 分钟前）。"""
+    from app.db import get_task_window_rounds_by_cell
+    rounds = [[("SiteA", "m", 0, 10)] for _ in range(5)]
+    sid, _ = await _seed_task(rounds)
+    w12 = await get_task_window_rounds_by_cell(sid, 90, "minute", 12)
+    assert len(w12[("SiteA", "m")]) == 2     # 仅 10、5 分钟前两轮
+    w30 = await get_task_window_rounds_by_cell(sid, 90, "minute", 30)
+    assert len(w30[("SiteA", "m")]) == 5     # 全部 5 轮
+
+
 # ---- 告警触发：连续 / 累计 ----
 
 @pytest.mark.asyncio

--- a/tests/test_migrate_alert_window.py
+++ b/tests/test_migrate_alert_window.py
@@ -1,0 +1,31 @@
+"""迁移脚本 scripts/migrate_alert_window_30min.py 的匹配逻辑单测。"""
+
+import importlib.util
+import json
+import os
+
+_PATH = os.path.join(os.path.dirname(__file__), "..",
+                     "scripts", "migrate_alert_window_30min.py")
+_spec = importlib.util.spec_from_file_location("migrate_alert_window_30min", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+_migrate = _mod._migrate_rules
+
+
+def test_count12_migrates_to_minute30():
+    d = json.loads(_migrate('{"mode":"count","value":12,"fail_in_window":3}'))
+    assert d["mode"] == "minute" and d["value"] == 30
+    assert d["fail_in_window"] == 3          # 其余字段保留
+
+
+def test_time1_migrates_to_minute30():
+    d = json.loads(_migrate('{"mode":"time","value":1}'))
+    assert d["mode"] == "minute" and d["value"] == 30
+
+
+def test_leaves_short_windows_and_empty_and_idempotent():
+    assert _migrate("") is None                       # 空 → 走新默认，不处理
+    assert _migrate('{"mode":"count","value":6}') is None     # 自定义短窗口不动
+    assert _migrate('{"mode":"time","value":2}') is None      # 2 小时不动
+    assert _migrate('{"mode":"minute","value":30}') is None   # 幂等：已是目标
+    assert _migrate("garbage") is None                # 非法 JSON 不动

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -77,7 +77,12 @@ def test_load_rules_garbage_falls_back():
 
 def test_load_rules_accepts_dict():
     r = _load_rules({"value": 6})
-    assert r["value"] == 6 and r["mode"] == "time"
+    assert r["value"] == 6 and r["mode"] == "minute"   # 默认窗口为 分钟/30
+
+
+def test_default_window_is_30_minutes():
+    assert DEFAULT_ALERT_RULES["mode"] == "minute"
+    assert DEFAULT_ALERT_RULES["value"] == 30
 
 
 # ---- _cell_state（解析不变，n 语义=窗口失败数）----


### PR DESCRIPTION
承接 #96 对称迟滞（恢复快慢 = 窗口长度）。把默认窗口从 1 小时缩到 30 分钟，并新增「分钟」模式，让短窗口可以按时间设置、与拨测间隔解耦。

Closes #98

## 改动

1. **后端「分钟」模式** — `get_task_window_rounds_by_cell` 时间窗口支持 `mode='minute'`（最近 N 分钟），与 `time`(小时) 共用裁剪逻辑
2. **默认窗口 小时/1 → 分钟/30** — `notifier.DEFAULT_ALERT_RULES` 与前端 `defaultAlertRules` 同步；恢复最长卡 ~30 分钟，改拨测频率不影响窗口时长
3. **前端** — 窗口模式下拉新增「最近 N 分钟」，单位提示走 `unitLabel()`
4. **迁移脚本** `scripts/migrate_alert_window_30min.py` — 部署时把线上旧的 1 小时窗口（显式 `次/12` 与老默认 `小时/1`）统一改为 `分钟/30`；空 alert_rules 走新默认自动变 30 分钟，无需迁移。幂等、走 db 层参数绑定（sqlite/Postgres 通用）

告警/恢复阈值（fail_consecutive / fail_in_window / recover_consecutive）保持不变。

## 部署步骤

部署新版本后,在容器内跑一次:
```
python -m scripts.migrate_alert_window_30min
```
（或 `python scripts/migrate_alert_window_30min.py`）会打印每条被迁移的任务。

## 测试

- 后端 `pytest tests/test_notifier.py tests/test_alert_db.py tests/test_alert_scheduler.py tests/test_schedule_notify.py tests/test_migrate_alert_window.py` → 68 passed
- 前端 `vitest run` → 60 passed；`bun run build` → ok