### PR TITLE
fix: 删除站点后清理遗留告警状态，消除残留告警卡

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -642,6 +642,23 @@ async def delete_profile(user_id: int, name: str):
             text("DELETE FROM profiles WHERE user_id=:uid AND name=:name"),
             {"uid": user_id, "name": name},
         )
+        # 清理该站点在各任务 alert_state 里的遗留告警格，
+        # 否则调度器会一直保留删除站点的告警状态，顶部告警卡永远消不掉。
+        cur = await conn.execute(
+            text("SELECT id, alert_state FROM scheduled_tasks WHERE user_id=:uid"),
+            {"uid": user_id},
+        )
+        for task_id, state_raw in cur.fetchall():
+            try:
+                states = json.loads(state_raw) if state_raw else {}
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(states, dict) and name in states:
+                states.pop(name, None)
+                await conn.execute(
+                    text("UPDATE scheduled_tasks SET alert_state=:s WHERE id=:tid"),
+                    {"s": json.dumps(states, ensure_ascii=False), "tid": task_id},
+                )
 
 
 async def rename_profile(user_id: int, old_name: str, new_name: str) -> bool:
@@ -712,14 +729,13 @@ async def rename_profile(user_id: int, old_name: str, new_name: str) -> bool:
                 {"uid": user_id, "new": new_name, "old": old_name},
             )
 
-        # 4. scheduled_tasks.profile_ids（JSON 字符串数组，Python 解析后替换再写回）
+        # 4. scheduled_tasks.profile_ids（JSON 字符串数组）+ alert_state（JSON，顶层以站点名为 key）
         cur = await conn.execute(
-            text("SELECT id, profile_ids FROM scheduled_tasks WHERE user_id=:uid"),
+            text("SELECT id, profile_ids, alert_state FROM scheduled_tasks WHERE user_id=:uid"),
             {"uid": user_id},
         )
         tasks = cur.fetchall()
-        for task_row in tasks:
-            task_id, pids_raw = task_row[0], task_row[1]
+        for task_id, pids_raw, state_raw in tasks:
             try:
                 pids = json.loads(pids_raw) if pids_raw else []
             except (json.JSONDecodeError, TypeError):
@@ -729,6 +745,17 @@ async def rename_profile(user_id: int, old_name: str, new_name: str) -> bool:
                 await conn.execute(
                     text("UPDATE scheduled_tasks SET profile_ids=:pids WHERE id=:tid"),
                     {"pids": json.dumps(new_pids), "tid": task_id},
+                )
+            # alert_state 顶层 key 跟随改名，否则旧名会留一张残卡
+            try:
+                states = json.loads(state_raw) if state_raw else {}
+            except (json.JSONDecodeError, TypeError):
+                states = {}
+            if isinstance(states, dict) and old_name in states:
+                states[new_name] = states.pop(old_name)
+                await conn.execute(
+                    text("UPDATE scheduled_tasks SET alert_state=:s WHERE id=:tid"),
+                    {"s": json.dumps(states, ensure_ascii=False), "tid": task_id},
                 )
 
         # 5. channel_diagnostics.profile_name

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -109,9 +109,11 @@ def _cell_state(value) -> Tuple[str, int]:
     return ALERT_OK, 0
 
 
-def aggregate_active_alerts(tasks: list) -> list:
+def aggregate_active_alerts(tasks: list, valid_profiles: set | None = None) -> list:
     """把多个任务的 alert_state 聚合为"当前正在告警"的格子列表，按 (站点,模型) 合并。
     入参 tasks: get_scheduled_tasks() 返回的 dict 列表（含 alert_state/name/id/profile_ids）。
+    valid_profiles: 若传入，仅保留仍存在的站点；过滤掉已删除站点遗留的告警格（自愈残留卡）。
+                    默认 None = 不过滤。
     前置条件：每个 task 应含 id 字段（来自 get_scheduled_tasks 的主键，必非空）。
     出参: [{"profile","model","fail_count","task_count","tasks":[{"id","name"}]}, ...]，
     按 (profile, model) 排序，便于前端稳定渲染。
@@ -121,6 +123,8 @@ def aggregate_active_alerts(tasks: list) -> list:
         states = _load_alert_states(t.get("alert_state"))
         for profile, models in states.items():
             if not isinstance(models, dict):
+                continue
+            if valid_profiles is not None and profile not in valid_profiles:
                 continue
             for model, cellval in models.items():
                 state, fail_count = _cell_state(cellval)

--- a/app/server.py
+++ b/app/server.py
@@ -2119,11 +2119,13 @@ def _mask_webhook(url: str) -> str:
 
 @app.get("/api/alerts/active")
 async def active_alerts(user: dict = Depends(get_current_user)):
-    """监控总览"当前告警区"用：返回当前正在告警的 (站点×模型) 合并列表。"""
-    from app.db import get_scheduled_tasks
+    """监控总览"当前告警区"用：返回当前正在告警的 (站点×模型) 合并列表。
+    仅保留仍存在的站点：删除站点后其遗留告警格不再返回（自愈残留卡）。"""
+    from app.db import get_scheduled_tasks, get_profiles
     from app.notifier import aggregate_active_alerts
     tasks = await get_scheduled_tasks(user["user_id"])
-    return {"alerts": aggregate_active_alerts(tasks)}
+    names = {p["name"] for p in await get_profiles(user["user_id"])}
+    return {"alerts": aggregate_active_alerts(tasks, valid_profiles=names)}
 
 
 @app.post("/api/schedules")

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -160,6 +160,21 @@ def test_aggregate_active_alerts_merges_by_cell():
     assert {t["id"] for t in cell["tasks"]} == {1, 2}
 
 
+def test_aggregate_active_alerts_filters_deleted_profiles():
+    """valid_profiles 传入时，已删除站点遗留的告警格不再返回（自愈残留卡）。"""
+    from app.notifier import aggregate_active_alerts
+    tasks = [
+        {"id": 1, "name": "任务A", "profile_ids": ["siteX"],
+         "alert_state": '{"siteX": {"gpt-4": {"s": "alerting", "n": 2}},'
+                        ' "deletedSite": {"gpt-4": {"s": "alerting", "n": 5}}}'},
+    ]
+    # 不传 valid_profiles：保持原行为，两个站点都返回
+    assert len(aggregate_active_alerts(tasks)) == 2
+    # 传入仅含 siteX：deletedSite 被过滤
+    out = aggregate_active_alerts(tasks, valid_profiles={"siteX"})
+    assert len(out) == 1 and out[0]["profile"] == "siteX"
+
+
 def test_aggregate_active_alerts_handles_empty_and_legacy():
     from app.notifier import aggregate_active_alerts
     tasks = [
@@ -198,3 +213,34 @@ async def test_active_alerts_empty_when_none(client):
     headers = await auth_headers(client)
     r = await client.get("/api/alerts/active", headers=headers)
     assert r.status_code == 200 and r.json()["alerts"] == []
+
+
+@pytest.mark.asyncio
+async def test_active_alerts_clears_after_profile_deleted(client):
+    """删除站点后，其遗留告警卡应从 /api/alerts/active 消失（自愈残留卡）。"""
+    from app.db import update_scheduled_task
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid, "alert_threshold": 90,
+    }, headers=headers)
+    sid = resp.json()["id"]
+    await update_scheduled_task(sid, alert_state='{"s": {"gpt-4o-mini": {"s": "alerting", "n": 2}}}')
+
+    # 删除前：有一张告警卡
+    r = await client.get("/api/alerts/active", headers=headers)
+    assert len(r.json()["alerts"]) == 1
+
+    # 删除站点
+    await client.delete("/api/profiles/s", headers=headers)
+
+    # 删除后：告警卡消失（valid_profiles 过滤 + delete_profile 已清 alert_state）
+    r = await client.get("/api/alerts/active", headers=headers)
+    assert r.json()["alerts"] == []
+
+    # alert_state 里该站点 key 也已被清掉
+    task = await get_scheduled_task(sid)
+    import json as _json
+    assert "s" not in _json.loads(task["alert_state"])

--- a/tests/test_rename_profile.py
+++ b/tests/test_rename_profile.py
@@ -10,6 +10,8 @@ from app.db import (
     get_profiles,
     create_scheduled_task,
     get_scheduled_task,
+    update_scheduled_task,
+    delete_profile,
     save_result,
     engine,
     rename_profile,
@@ -108,6 +110,43 @@ async def test_rename_profile_not_found():
 
     with pytest.raises((ValueError, LookupError)):
         await rename_profile(uid, "Ghost", "NewGhost")
+
+
+@pytest.mark.asyncio
+async def test_rename_profile_migrates_alert_state():
+    """改名后 scheduled_tasks.alert_state 顶层站点 key 跟随迁移，旧名不残留。"""
+    uid = await create_user("rename_alert@example.com", "pw")
+    await upsert_profile(uid, "OldSite", base_url="https://api.example.com", models=["gpt-4o"])
+    sid = await create_scheduled_task(uid, "t", ["OldSite"], {}, "interval", "300")
+    await update_scheduled_task(
+        sid, alert_state='{"OldSite": {"gpt-4o": {"s": "alerting", "n": 3}}}')
+
+    await rename_profile(uid, "OldSite", "NewSite")
+
+    task = await get_scheduled_task(sid)
+    states = json.loads(task["alert_state"])
+    assert "OldSite" not in states, "旧名不应残留在 alert_state"
+    assert states.get("NewSite", {}).get("gpt-4o", {}).get("s") == "alerting", \
+        "告警状态应迁移到新名下"
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_clears_alert_state():
+    """删除站点后 scheduled_tasks.alert_state 里该站点 key 被清除。"""
+    uid = await create_user("delete_alert@example.com", "pw")
+    await upsert_profile(uid, "DelSite", base_url="https://api.example.com", models=["gpt-4o"])
+    sid = await create_scheduled_task(uid, "t", ["DelSite"], {}, "interval", "300")
+    await update_scheduled_task(
+        sid,
+        alert_state='{"DelSite": {"gpt-4o": {"s": "alerting", "n": 3}},'
+                    ' "KeepSite": {"gpt-4o": {"s": "alerting", "n": 1}}}')
+
+    await delete_profile(uid, "DelSite")
+
+    task = await get_scheduled_task(sid)
+    states = json.loads(task["alert_state"])
+    assert "DelSite" not in states, "已删除站点不应残留在 alert_state"
+    assert "KeepSite" in states, "其它站点的告警状态应保留"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题
删除站点后，监控总览顶部仍显示该站点的告警卡（如 `fastcc-max × claude-opus-4-8 近窗口失败 3 次`），无法消除。

## 根因
告警状态存于 `scheduled_tasks.alert_state`（JSON，以站点名为 key）：
- `delete_profile` 只删 profiles 表，没清 alert_state 里的站点 key。
- 调度器对「本轮没出现但仍在告警的格子」会保留状态；删掉的站点永不再出现在跑批 cells 中，告警卡永远消不掉。
- `/api/alerts/active` 不校验站点是否仍存在。

## 改动
1. `aggregate_active_alerts` 增加可选 `valid_profiles` 过滤；`/api/alerts/active` 传入当前站点名集合 → **立即自愈线上已残留的告警卡**。
2. `delete_profile` 同事务清理各任务 alert_state 里被删站点的 key（保持库干净，停止飞书复评）。
3. 顺手修 `rename_profile`：迁移 alert_state 顶层站点 key，否则改名也会留旧名残卡。
4. 补充 `test_alert_api` / `test_rename_profile` 覆盖（含端到端删站点后告警卡消失）。

## 测试
```
pytest tests/test_alert_api.py tests/test_rename_profile.py  # 22 passed
```

Closes #100