### PR TITLE
fix: 移动端顶部菜单栏遮挡搜索框与页签

### DIFF
--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1899,9 +1899,24 @@ thead th.active-sort .sort-arrow { opacity: 1; }
 
 /* ---- Responsive ---- */
 @media (max-width: 768px) {
-  .header { padding: 0 16px; }
-  .tab-bar { padding: 0 16px; overflow-x: auto; }
-  .main { padding: 16px; }
+  /* 顶栏随页面滚走：不再 fixed，避免写死的 padding-top:128px 在窄屏失配遮挡内容 */
+  .header {
+    position: static;
+    height: auto;
+    min-height: 56px;
+    padding: 8px 16px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .tab-bar {
+    position: static;
+    top: auto;
+    padding: 0 16px;
+    overflow-x: auto;
+  }
+  .main { padding: 16px; }      /* 覆盖桌面的 padding-top:128px */
+  .version-badge { display: none; }     /* 省空间：手机上隐藏版本号 */
+  .global-time-range { margin-left: auto; }
   .form-grid { grid-template-columns: 1fr; }
   .detail-content { grid-template-columns: 1fr; }
   .metrics-grid { grid-template-columns: repeat(2, 1fr); }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1916,7 +1916,6 @@ thead th.active-sort .sort-arrow { opacity: 1; }
   }
   .main { padding: 16px; }      /* 覆盖桌面的 padding-top:128px */
   .version-badge { display: none; }     /* 省空间：手机上隐藏版本号 */
-  .global-time-range { margin-left: auto; }
   .form-grid { grid-template-columns: 1fr; }
   .detail-content { grid-template-columns: 1fr; }
   .metrics-grid { grid-template-columns: repeat(2, 1fr); }


### PR DESCRIPTION
## 问题
手机打开时，顶部固定菜单栏会挡住下方的搜索框、页签等内容。

## 根因
`header`(fixed,64px) + `.tab-bar`(fixed,top:64px) + `.main{padding-top:128px}` 是写死的魔法值。窄屏下 tab-bar 的页签+时间筛选会换行（实测 375px 下 tab-bar 高 ~76px），header+tab-bar 总高超过 128px，正好盖住下方约 10+px 内容。

## 改动（仅 ≤768px media query）
- `.header` / `.tab-bar` 改 `position:static`，顶栏随页面滚走 → 内容在正常流中永不被遮。
- `.main` 去掉 128px 顶部偏移。
- 隐藏 `.version-badge` 省空间。
- 桌面端（>768px）完全不变，仍固定吸顶。

> 未走 sticky 方案：body 有 `overflow-x:hidden` 会破坏 position:sticky。

## 验证
Playwright 375px 截图 /sites：header→tab-bar→工具栏依次排开互不重叠，搜索框/页签/筛选均可见可点。前端 `bun run build` 通过。

Closes #101