### PR TITLE
fix: 告警规则校验放行 minute 模式，修默认值无法保存

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -253,7 +253,7 @@ async def _maybe_send_alert(task_id: int, task_row: dict, run_ids: list):
 
     threshold = int(task_row.get("alert_threshold") or 90)
     rules = _load_rules(task_row.get("alert_rules"))
-    mode = rules.get("mode", "time")
+    mode = rules.get("mode", "minute")   # _load_rules 已补默认，与 DEFAULT_ALERT_RULES 对齐
     value = int(rules.get("value", 1) or 1)
     # 各格窗口内坏轮序列（含本轮，本轮结果已落库）
     windows = await get_task_window_rounds_by_cell(task_id, threshold, mode, value)

--- a/app/server.py
+++ b/app/server.py
@@ -2091,8 +2091,8 @@ async def _extract_alert_fields(body: dict, user_id: int):
             rules = {}
         if not isinstance(rules, dict):
             return None, "alert_rules 必须是对象"
-        if rules.get("mode") not in (None, "time", "count"):
-            return None, "alert_rules.mode 必须是 time 或 count"
+        if rules.get("mode") not in (None, "time", "minute", "count"):
+            return None, "alert_rules.mode 必须是 time、minute 或 count"
         for k in ("value", "fail_consecutive", "fail_in_window", "recover_consecutive"):
             if rules.get(k) is not None:
                 try:

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -61,6 +61,32 @@ async def test_create_schedule_rejects_bad_threshold(client):
 
 
 @pytest.mark.asyncio
+async def test_create_schedule_accepts_minute_mode(client):
+    """前端默认 alert_rules.mode='minute'，后端必须放行（否则用默认值就报错）。"""
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    nid = await _make_notifier(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"], "schedule_value": "300",
+        "alert_enabled": True, "alert_notifier_id": nid, "alert_threshold": 90,
+        "alert_rules": {"mode": "minute", "value": 30, "fail_consecutive": 2,
+                        "fail_in_window": 3, "recover_consecutive": 2},
+    }, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_rejects_bad_mode(client):
+    headers = await auth_headers(client)
+    await _make_profile(client, headers)
+    resp = await client.post("/api/schedules", json={
+        "name": "t", "profile_ids": ["s"],
+        "alert_rules": {"mode": "weekly", "value": 1},
+    }, headers=headers)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_notifier_crud_api(client):
     headers = await auth_headers(client)
     r = await client.post("/api/notifiers",


### PR DESCRIPTION
## 现象
新建持续监控、勾选告警策略，啥也不改用默认值，就提示「alert_rules.mode 必须是 time 或 count」，无法保存。

## 根因
`bf82b58`（新增告警「分钟」窗口模式）的回归：
- 前端默认发 `mode:'minute', value:30`（`SiteSchedulesTab.vue:474`）。
- 后端校验 `server.py:2094` 仍只允许 `time/count`，把 minute 拒了。
- 调度器/notifier 早已支持 minute（`db.py:954`、`notifier.py:25` 默认就是 minute），仅这条校验漏改。

## 改动
- `server.py` 校验放行 `minute`，文案改为「time、minute 或 count」。
- 补两条测试：默认 minute 规则可保存(200)、非法 mode 仍拒(400)。

## 测试
`pytest tests/test_alert_api.py` → 15 passed。

Closes #104