### PR TITLE
feat: 执行记录列表与首页站点监控列表展示增强（Token/TPOT/失败·错误类型）

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1813,7 +1813,8 @@ async def get_sites_summary(user_id: int, hours: int | None = None) -> list[dict
         cur = await conn.execute(
             text(f"""
                 SELECT r.id, r.profile_name, r.timestamp, r.summary_json,
-                       r.percentiles_json, r.config_json, r.scheduled_task_id
+                       r.percentiles_json, r.config_json, r.scheduled_task_id,
+                       r.errors_json
                 FROM results r
                 WHERE r.user_id=:uid
                   AND r.profile_name IN ({placeholders})
@@ -1848,12 +1849,17 @@ async def get_sites_summary(user_id: int, hours: int | None = None) -> list[dict
                 p = json.loads(r[4]) if r[4] else {}  # percentiles_json
             except (json.JSONDecodeError, TypeError):
                 p = {}
+            try:
+                errs = json.loads(r[7]) if r[7] else {}
+            except (json.JSONDecodeError, TypeError):
+                errs = {}
             latest_results.append({
                 "timestamp": r[2],
                 "summary": s,
                 "percentiles": p,
                 "config": json.loads(r[5]) if r[5] else {},
                 "scheduled_task_id": r[6],
+                "errors": errs,
             })
 
         summary[pn]["latest_results"] = latest_results

--- a/frontend/src/components/SiteHealthBoard.vue
+++ b/frontend/src/components/SiteHealthBoard.vue
@@ -8,6 +8,8 @@
         <th class="th-sort" @click="setSort('ttft')">TTFT P50<span class="sarr">{{ sortArrow('ttft') }}</span></th>
         <th>趋势</th>
         <th class="th-sort" @click="setSort('tps')">Token/s<span class="sarr">{{ sortArrow('tps') }}</span></th>
+        <th class="th-sort" @click="setSort('inTok')" title="每请求输入 Token (P50)">输入Tok<span class="sarr">{{ sortArrow('inTok') }}</span></th>
+        <th class="th-sort" @click="setSort('outTok')" title="每请求输出 Token (P50)">输出Tok<span class="sarr">{{ sortArrow('outTok') }}</span></th>
         <th class="th-sort" @click="setSort('rate')">成功率<span class="sarr">{{ sortArrow('rate') }}</span></th>
         <th class="th-sort" @click="setSort('last')">最近测试<span class="sarr">{{ sortArrow('last') }}</span></th>
         <th></th>
@@ -25,6 +27,8 @@
             <td>{{ siteAvg(site,'ttft') != null ? fmtTime(siteAvg(site,'ttft')) : '-' }} <span class="agg" v-if="siteAvg(site,'ttft')!=null">平均</span></td>
             <td></td>
             <td>{{ siteAvg(site,'tps') != null ? fmtNum(siteAvg(site,'tps'),0) : '-' }}</td>
+            <td>{{ siteAvg(site,'inTok') != null ? fmtNum(siteAvg(site,'inTok'),0) : '-' }}</td>
+            <td>{{ siteAvg(site,'outTok') != null ? fmtNum(siteAvg(site,'outTok'),0) : '-' }}</td>
             <td><span class="rate" :class="rateClass(siteRate(site))">{{ siteRate(site)!=null ? fmtPct(siteRate(site)) : '-' }}</span></td>
             <td>{{ site.last_test_at ? relativeTime(site.last_test_at) : '未测试' }}</td>
             <td class="row-actions" @click.stop>
@@ -42,6 +46,8 @@
               <span v-else class="spark-na">-</span>
             </td>
             <td>{{ m.tps!=null ? fmtNum(m.tps,0) : '-' }}</td>
+            <td>{{ m.inTok!=null ? fmtNum(m.inTok,0) : '-' }}</td>
+            <td>{{ m.outTok!=null ? fmtNum(m.outTok,0) : '-' }}</td>
             <td><span class="rate" :class="rateClass(m.successRate)">{{ m.successRate!=null ? fmtPct(m.successRate) : '-' }}</span></td>
             <td></td>
             <td></td>
@@ -110,6 +116,8 @@ function sortValue(site, key) {
     case 'avail': { const s = siteSeries(site).filter(v => v != null); return s.length ? s.reduce((a, b) => a + b, 0) / s.length : null; }
     case 'ttft': return siteAvg(site, 'ttft');
     case 'tps': return siteAvg(site, 'tps');
+    case 'inTok': return siteAvg(site, 'inTok');
+    case 'outTok': return siteAvg(site, 'outTok');
     case 'rate': return siteRate(site);
     case 'last': return site.last_test_at || '';
     default: return null;

--- a/frontend/src/components/SiteHealthBoard.vue
+++ b/frontend/src/components/SiteHealthBoard.vue
@@ -22,6 +22,7 @@
               <button class="fav" :class="{ on: isFavorite(site.profile.name) }" @click.stop="emit('toggle-favorite', site.profile.name)" :title="isFavorite(site.profile.name) ? '取消收藏' : '收藏'">★</button>
               <router-link class="sname" :to="`/sites/${encodeURIComponent(site.profile.name)}`" @click.stop>{{ site.profile.name }}</router-link>
               <span class="mcount">{{ getModelMetrics(site).length }} 模型</span>
+              <span v-if="topError(site)" class="err-pill" :title="errPillTitle(site)">{{ topError(site).type }} ×{{ topError(site).count }}</span>
             </td>
             <td><span class="avail-bars" :class="{ dim: isExpanded(site.profile.name) }"><i v-for="(rate,i) in siteSeries(site)" :key="i" :class="'ab-'+availabilityClass(rate)" :title="rate==null?'无数据':('成功率 '+rate.toFixed(1)+'%')"></i></span></td>
             <td>{{ siteAvg(site,'ttft') != null ? fmtTime(siteAvg(site,'ttft')) : '-' }} <span class="agg" v-if="siteAvg(site,'ttft')!=null">平均</span></td>
@@ -61,7 +62,7 @@
 <script setup>
 import { ref, computed } from 'vue';
 import { fmtTime, fmtPct, fmtNum } from '../utils/formatters';
-import { getModelMetrics, sparklinePoints, latencyTrendColor, availabilityClass, siteAvgSeries, seriesAvg } from '../utils/siteMetrics';
+import { getModelMetrics, sparklinePoints, latencyTrendColor, availabilityClass, siteAvgSeries, seriesAvg, getErrorTypes, getTotalErrorCount } from '../utils/siteMetrics';
 
 const props = defineProps({
   sites: { type: Array, default: () => [] },
@@ -72,6 +73,20 @@ const props = defineProps({
 const emit = defineEmits(['test-site', 'toggle-favorite', 'navigate-to-detail']);
 
 function isFavorite(name) { return props.favorites.has(name); }
+
+// 站点主要错误类型徽章：仅在所选范围内有失败时显示，给已亮红的站点补上「为什么」
+function topError(site) {
+  const types = getErrorTypes(site);
+  if (!types.length) return null;
+  const t = types[0].type || '';
+  return { type: t.length > 8 ? t.slice(0, 8) + '…' : t, count: types[0].count };
+}
+function errPillTitle(site) {
+  const types = getErrorTypes(site);
+  if (!types.length) return '';
+  const lines = types.map(e => `${e.type}: ${e.count}`);
+  return `主要错误类型\n${lines.join('\n')}\n合计 ${getTotalErrorCount(site)} 次`;
+}
 
 // ---- 看板展开态（不持久化）+ 可用性辅助 ----
 const expanded = ref(new Set());
@@ -195,6 +210,8 @@ table.board td { padding:8px 10px; border-bottom:1px solid var(--border-subtle);
 .sname { font-weight:700; color:var(--text-primary); text-decoration:none; }
 .sname:hover { color:var(--accent); }
 .mcount { font-size:10.5px; font-weight:600; color:#6b7280; background:var(--border-subtle); border-radius:999px; padding:1px 7px; margin-left:6px; }
+/* 错误类型徽章：克制的琥珀色，不抢健康点的红，只解释「为什么有失败」 */
+.err-pill { font-size:10.5px; font-weight:600; color:#9a5b00; background:#fdf0d5; border:1px solid #f3d9a6; border-radius:999px; padding:1px 7px; margin-left:6px; cursor:default; white-space:nowrap; }
 .fav { background:none; border:none; cursor:pointer; color:var(--text-tertiary); font-size:13px; margin-right:7px; }
 .fav.on { color:var(--warning); }
 .agg { font-size:9px; color:var(--text-tertiary); }

--- a/frontend/src/utils/siteMetrics.js
+++ b/frontend/src/utils/siteMetrics.js
@@ -38,10 +38,16 @@ export function getModelMetrics(site) {
     const tpsList = results.map(r => r.summary?.token_throughput_tps).filter(v => v != null && v > 0);
     const tps = tpsList.length ? tpsList.reduce((a, b) => a + b, 0) / tpsList.length : null;
 
+    // 输入/输出 token：取每条结果每请求 P50 的均值
+    const inToks = results.map(r => r.summary?.input_tokens?.P50).filter(v => v != null);
+    const inTok = inToks.length ? inToks.reduce((a, b) => a + b, 0) / inToks.length : null;
+    const outToks = results.map(r => r.summary?.output_tokens?.P50).filter(v => v != null);
+    const outTok = outToks.length ? outToks.reduce((a, b) => a + b, 0) / outToks.length : null;
+
     // Sparkline: TTFT 延迟趋势（优先后端 7 天 sparkline_data，回退 latest_results）
     const latencyTrend = getSparklineTrend(site, model);
 
-    return { model, ttft, tpot, e2e, tps, successRate, latencyTrend };
+    return { model, ttft, tpot, e2e, tps, inTok, outTok, successRate, latencyTrend };
   }).sort((a, b) => a.model.localeCompare(b.model));
 }
 

--- a/frontend/src/utils/siteMetrics.js
+++ b/frontend/src/utils/siteMetrics.js
@@ -106,6 +106,15 @@ export function getErrorTypes(site) {
   const results = site.latest_results || [];
   const errorCounts = {};
   for (const r of results) {
+    // 优先用记录里聚合好的 error_counts（{类型: 次数}），由后端 report["errors"] 提供
+    const counts = r.errors;
+    if (counts && typeof counts === 'object' && !Array.isArray(counts)) {
+      for (const [type, n] of Object.entries(counts)) {
+        if (type) errorCounts[type] = (errorCounts[type] || 0) + (n || 0);
+      }
+      continue;
+    }
+    // 回退：从 error_details 里数 error_type（兼容可能带该字段的旧数据）
     const errDetails = r.error_details;
     if (Array.isArray(errDetails)) {
       for (const e of errDetails) {

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -87,7 +87,9 @@
               <th style="width:50px">并发</th>
               <th style="width:55px">模式</th>
               <th style="width:72px">成功率</th>
+              <th style="width:70px" title="失败请求数（悬停看错误类型）">失败</th>
               <th style="width:78px">TTFT P50</th>
+              <th style="width:78px" title="每输出 token 间隔 P50（吐字速度）">TPOT P50</th>
               <th style="width:78px">E2E P50</th>
               <th style="width:72px">吞吐量</th>
               <th style="width:72px" title="每请求输入 Token (P50)">输入 Tok</th>
@@ -99,7 +101,7 @@
           <tbody>
             <template v-if="!filtered.length">
               <tr>
-                <td colspan="14" style="text-align:center;padding:40px;color:var(--text-tertiary)">暂无记录</td>
+                <td colspan="16" style="text-align:center;padding:40px;color:var(--text-tertiary)">暂无记录</td>
               </tr>
             </template>
             <template v-for="(r, idx) in filtered" :key="r.filename || idx">
@@ -118,7 +120,12 @@
                 <td style="font-size:12px">{{ r.config?.concurrency || '-' }}</td>
                 <td style="font-size:12px">{{ r.config?.mode || '-' }}</td>
                 <td :class="successRateClass(r.summary?.success_rate)" style="font-weight:600;font-size:12px">{{ fmtPct(r.summary?.success_rate) }}</td>
+                <td style="font-size:12px;white-space:nowrap" :title="errorTypesTitle(r)">
+                  <span :class="r.summary?.failed_count ? 'danger' : ''" style="font-weight:600">{{ r.summary?.failed_count || 0 }}</span>
+                  <span v-if="topErrorType(r)" style="color:var(--text-tertiary);font-size:10px;margin-left:3px">{{ topErrorType(r) }}</span>
+                </td>
                 <td :class="latencyClass(r.percentiles?.TTFT?.P50, 0.5, 2)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtTime(r.percentiles?.TTFT?.P50) }}</td>
+                <td :class="latencyClass(r.percentiles?.TPOT?.P50, 0.05, 0.2)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtTime(r.percentiles?.TPOT?.P50) }}</td>
                 <td :class="latencyClass(r.percentiles?.E2E?.P50, 2, 10)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtTime(r.percentiles?.E2E?.P50) }}</td>
                 <td :class="qualityClass(r.summary?.throughput_rps, 20, 5)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtNum(r.summary?.throughput_rps) }}/s</td>
                 <td style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtNum(r.summary?.input_tokens?.P50, 0) }}</td>
@@ -136,7 +143,7 @@
               </tr>
               <!-- 展开详情 -->
               <tr v-if="expandedRows.has(idx)" class="history-detail-row">
-                <td colspan="14" style="padding:0">
+                <td colspan="16" style="padding:0">
                   <div style="padding:12px 16px;background:var(--bg);border-top:1px solid var(--border-subtle)" v-html="detailHtml[idx]"></div>
                 </td>
               </tr>
@@ -442,6 +449,27 @@ const compareData = computed(() => {
 function successRateClass(rate) {
   if (rate == null) return '';
   return rate >= 95 ? 'success' : rate >= 80 ? 'warning' : 'danger';
+}
+
+// 记录顶层 errors 是 {错误类型: 次数}（后端 report["errors"]），按次数降序
+function sortedErrorEntries(r) {
+  const errs = r.errors || {};
+  return Object.entries(errs).filter(([t]) => t).sort((a, b) => b[1] - a[1]);
+}
+
+// 失败列内联展示的主要错误类型（截断，避免过长撑宽）
+function topErrorType(r) {
+  const entries = sortedErrorEntries(r);
+  if (!entries.length) return '';
+  const t = entries[0][0];
+  return t.length > 10 ? t.slice(0, 10) + '…' : t;
+}
+
+// 失败列悬停提示：完整错误类型 + 次数
+function errorTypesTitle(r) {
+  const entries = sortedErrorEntries(r);
+  if (!entries.length) return r.summary?.failed_count ? '有失败但无错误类型明细' : '无失败';
+  return entries.map(([t, c]) => `${t}: ${c}`).join('\n');
 }
 
 function latencyClass(value, good, warn) {

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -90,6 +90,8 @@
               <th style="width:78px">TTFT P50</th>
               <th style="width:78px">E2E P50</th>
               <th style="width:72px">吞吐量</th>
+              <th style="width:72px" title="每请求输入 Token (P50)">输入 Tok</th>
+              <th style="width:72px" title="每请求输出 Token (P50)">输出 Tok</th>
               <th style="width:55px">费用</th>
               <th style="width:80px"></th>
             </tr>
@@ -97,7 +99,7 @@
           <tbody>
             <template v-if="!filtered.length">
               <tr>
-                <td colspan="12" style="text-align:center;padding:40px;color:var(--text-tertiary)">暂无记录</td>
+                <td colspan="14" style="text-align:center;padding:40px;color:var(--text-tertiary)">暂无记录</td>
               </tr>
             </template>
             <template v-for="(r, idx) in filtered" :key="r.filename || idx">
@@ -119,6 +121,8 @@
                 <td :class="latencyClass(r.percentiles?.TTFT?.P50, 0.5, 2)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtTime(r.percentiles?.TTFT?.P50) }}</td>
                 <td :class="latencyClass(r.percentiles?.E2E?.P50, 2, 10)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtTime(r.percentiles?.E2E?.P50) }}</td>
                 <td :class="qualityClass(r.summary?.throughput_rps, 20, 5)" style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtNum(r.summary?.throughput_rps) }}/s</td>
+                <td style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtNum(r.summary?.input_tokens?.P50, 0) }}</td>
+                <td style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtNum(r.summary?.output_tokens?.P50, 0) }}</td>
                 <td style="font-family:var(--font-mono);font-size:12px;font-weight:500">{{ fmtCostShort(r.summary?.cost_total_usd) }}</td>
                 <td style="white-space:nowrap;text-align:right">
                   <span class="history-row-source" v-if="r.schedule_name" :title="r.schedule_name" style="font-size:10px;color:var(--text-tertiary);margin-right:4px">定时</span>
@@ -132,7 +136,7 @@
               </tr>
               <!-- 展开详情 -->
               <tr v-if="expandedRows.has(idx)" class="history-detail-row">
-                <td colspan="12" style="padding:0">
+                <td colspan="14" style="padding:0">
                   <div style="padding:12px 16px;background:var(--bg);border-top:1px solid var(--border-subtle)" v-html="detailHtml[idx]"></div>
                 </td>
               </tr>


### PR DESCRIPTION
Closes #106
Closes #108

两处列表补充可展示信息，分两批提交。

## 一、输入/输出 Token（#106）
口径：每请求 P50。
- 执行记录表：吞吐量与费用之间加「输入 Tok」「输出 Tok」
- 站点看板：站点行 + 模型展开行在 Token/s 后加输入/输出 Token，可排序

## 二、TPOT / 失败·错误类型 / 错误徽章（#108）
**执行记录列表**
- 新增 **TPOT P50** 列，补齐 TTFT/TPOT/E2E 延迟三件套
- 新增 **「失败」列**：失败请求数 + 主要错误类型（内联截断，悬停看完整「类型: 次数」）

**首页站点监控列表**
- 站点名旁新增**主要错误类型徽章**：红了一眼看出是超时/限流。克制琥珀色、仅在所选范围有失败时显示，不抢健康点的红（遵循「AI 站点不可用是常态、别一坏就标红」）
- 后端 `/api/sites/summary` 补查 `errors_json` 并随 `latest_results` 下发（原本不含，徽章无数据可用）

**附带修复**
- `siteMetrics.getErrorTypes` 原按 `error_details[].error_type` 统计，但后端无该字段、错误类型聚合在记录顶层 `errors`(`{类型:次数}`)。改为优先读 `errors`、回退旧逻辑。此前依赖它的**详情页「主要错误类型」实际一直为空**，一并修好。

## 测试
- 前端 vitest 60 passed；vite build 通过
- 后端 pytest（sqlite 优化 + 时间范围）25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)