### PR TITLE
docs: 开发流程由 git worktree 改为普通 feature 分支

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: Issue → 分支 → 实现 → PR 完整工作流。实现阶段�
 
 # Issue Workflow（融合 Superpowers）
 
-标准化开发流程：Issue 关联 → 工作树 → 实现 → PR → 等待审核。
+标准化开发流程：Issue 关联 → 分支 → 实现 → PR → 等待审核。
 
 实现阶段分为两档：
 - **简单改动**（拼写、单行修复、纯配置）→ 直接编码
@@ -16,7 +16,7 @@ description: Issue → 分支 → 实现 → PR 完整工作流。实现阶段�
 ```
 gh issue list / create
       ↓
-创建 worktree + 分支: {type}/issue-{N}-{slug}
+创建分支: {type}/issue-{N}-{slug}
       ↓
 ┌─ 简单改动 → 直接实现
 └─ 复杂改动 → brainstorming → spec → [subagent 审 spec] → writing-plans → [subagent 开发]
@@ -40,11 +40,13 @@ gh issue list --state open --limit 30
 gh issue create --title "简短描述" --body "详细说明"
 ```
 
-## 2. 创建 Worktree + 分支
+## 2. 创建分支
+
+在主仓库直接开分支，**不用 git worktree**（worktree 下 Edit/Write 易误写主仓库、且需单独 `bun install`，单人项目得不偿失）。
 
 ```bash
 git checkout main && git pull
-git worktree add -b {type}/issue-{N}-{slug} ../worktrees/issue-{N}
+git checkout -b {type}/issue-{N}-{slug}
 ```
 
 - **type**: fix / feat / refactor / docs / chore
@@ -138,7 +140,8 @@ EOF
 ```bash
 gh issue close {N}
 gh issue view {N} --json state
-git worktree remove ../worktrees/issue-{N}
+git checkout main && git pull
+git branch -d {type}/issue-{N}-{slug}
 ```
 
 ## 异常处理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 ### Branch + PR flow
 
 1. 分支命名：`fix/issue-<N>-<slug>` 或 `feat/issue-<N>-<slug>`
-2. 使用 `git worktree` 隔离开发（参见 `issue-workflow` skill）
+2. 在主仓库直接开分支开发：`git checkout -b <branch>`（不用 git worktree，参见 `issue-workflow` skill）
 3. Commit（不含 Co-Authored-By），包含 issue 引用
 4. Push 分支 + `gh pr create`（PR body 含 `Closes #N`）
 5. 等待人工审核后合并


### PR DESCRIPTION
Closes #109

把开发隔离方式从 `git worktree` 改为主仓库内普通 feature 分支。

## 改动
- **CLAUDE.md** — Branch+PR flow 第 2 步：`git worktree` 隔离 → `git checkout -b` 开分支
- **.claude/skills/issue-workflow/SKILL.md** — 标题流程、流程图、第 2 步「创建分支」、第 6 步收尾,全部由 worktree 命令改为分支命令,并补一句不用 worktree 的原因

## 原因
- worktree 下用绝对路径 Edit/Write 易误写到主仓库,需导补丁来回搬
- worktree 有独立 node_modules,要单独 bun install 才能跑测试/构建
- 单人项目用不到 worktree 的并行 / 保持 main 干净收益

纯文档,无代码逻辑变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)